### PR TITLE
Tweaks to directory naming.

### DIFF
--- a/app/jobs/fetch_job.rb
+++ b/app/jobs/fetch_job.rb
@@ -37,7 +37,7 @@ class FetchJob < ApplicationJob
      '--authurl', fetch_month.wasapi_provider_config.authurl,
      '--username', fetch_month.wasapi_account_config.username,
      '--password', fetch_month.wasapi_account_config.password,
-     '--outputBaseDir', fetch_month.crawl_directory,
+     '--outputBaseDir', fetch_month.crawl_directory + '/',
      '--collectionId', fetch_month.collection.wasapi_collection_id,
      '--resume']
   end

--- a/app/models/fetch_month.rb
+++ b/app/models/fetch_month.rb
@@ -10,7 +10,8 @@ class FetchMonth < ApplicationRecord
   end
 
   def job_directory
-    File.join("#{collection.wasapi_provider.upcase}_#{collection.wasapi_collection_id}", "#{year}_#{month}")
+    date_part = "#{year}_#{month.to_s.rjust(2, '0')}"
+    File.join("#{collection.wasapi_provider.upcase}_#{collection.wasapi_collection_id}", date_part)
   end
 
   def crawl_start_after

--- a/spec/jobs/fetch_job_spec.rb
+++ b/spec/jobs/fetch_job_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe FetchJob do
                                          '--password',
                                          'pass',
                                          '--outputBaseDir',
-                                         'tmp/jobs/AIT_915/2017_11',
+                                         'tmp/jobs/AIT_915/2017_11/',
                                          '--collectionId',
                                          '915',
                                          '--resume'])

--- a/spec/models/fetch_month_spec.rb
+++ b/spec/models/fetch_month_spec.rb
@@ -16,6 +16,13 @@ RSpec.describe FetchMonth, type: :model do
     it 'returns the correct job directory' do
       expect(fetch_month.job_directory).to eq('AIT_915/2017_11')
     end
+    context 'when the month is a single digit' do
+      let(:fetch_month) { create(:fetch_month, collection: collection, month: 1) }
+
+      it 'returns the correct job directory with month padded' do
+        expect(fetch_month.job_directory).to eq('AIT_915/2017_01')
+      end
+    end
   end
 
   describe '#crawl_start_after' do


### PR DESCRIPTION
* Pads month in job directory name.
* Adds trailing slash to outputBaseDir when invoking WASAPI downloader.