### PR TITLE
Pin sidekiq to version 5.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,8 @@ gem 'dor-services-client'
 gem 'dor-workflow-client', '~> 3.4', '>= 3.4.2'
 gem 'honeybadger'
 gem 'okcomputer'
-gem 'sidekiq'
+# TODO: Unpin from 5.x once we have switched to using systemd to manage the sidekiq daemon
+gem 'sidekiq', '~> 5.2'
 gem 'simple_form'
 gem 'whenever', '~> 1.0', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -288,11 +288,11 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
-    sidekiq (6.0.0)
-      connection_pool (>= 2.2.2)
-      rack (>= 2.0.0)
-      rack-protection (>= 2.0.0)
-      redis (>= 4.1.0)
+    sidekiq (5.2.7)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack (>= 1.5.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
     simple_form (4.1.0)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -362,7 +362,7 @@ DEPENDENCIES
   rspec-rails (~> 3.8)
   rspec_junit_formatter
   rubocop
-  sidekiq
+  sidekiq (~> 5.2)
   simple_form
   simplecov
   spring


### PR DESCRIPTION
Now that Sidekiq 6 has been released, which removes the ability to daemonize
sidekiq, we must pin sidekiq until we are daemonizing sidekiq via systemd (vs.
the sidekiq executable in the bundle). Note the tracking issue in
capistrano-sidekiq: https://github.com/seuros/capistrano-sidekiq/issues/224