### PR TITLE
Remove token_header keyword arg when configuring dor-services-client

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,7 +124,7 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.3.2)
-    dor-services-client (2.5.1)
+    dor-services-client (2.6.2)
       activesupport (>= 4.2, < 7)
       cocina-models (~> 0.1.0)
       faraday (~> 0.15)

--- a/app/jobs/fetch_job.rb
+++ b/app/jobs/fetch_job.rb
@@ -56,8 +56,7 @@ class FetchJob < ApplicationJob
 
   def dor_services_client
     @dor_services_client ||= Dor::Services::Client.configure(url: Settings.dor_services.url,
-                                                             token: Settings.dor_services.token,
-                                                             token_header: Settings.dor_services.token_header)
+                                                             token: Settings.dor_services.token)
   end
 
   def register

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -9,6 +9,5 @@ workflow:
 dor_services:
   url:  'https://dor-services-test.stanford.test'
   token: secret-token
-  token_header: 'X-Auth'
 
 argo_view_url: https://argo.stanford.edu/view/%s


### PR DESCRIPTION
This is no longer required, and in fact can break the client if the header value (from shared_configs) is unset. This is what broke the workflow service connection to dor-services-app.