### PR TITLE
tell coveralls it's a rails app

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'simplecov'
-SimpleCov.start do
+SimpleCov.start :rails do
   add_filter 'spec'
 end
 


### PR DESCRIPTION
## Why was this change made?

Telling simplecov it's a Rails app means it will give more accurate stats on code coverage.

## Was the documentation updated?

N/A