### PR TITLE
Fix coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,21 +104,28 @@ jobs:
           command: |
             curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
             chmod +x ./cc-test-reporter
-            ./cc-test-reporter before-build
       # Run rspec in parallel
       - run:
           command: |
-            mkdir /tmp/test-results
+            mkdir -p test-results/rspec
+            ./cc-test-reporter before-build
             TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
-            bundle exec rspec $TESTFILES --profile 10 --format RspecJunitFormatter --out /tmp/test-results/rspec.xml --format progress
+            bundle exec rspec --profile 10 --format RspecJunitFormatter --out test-results/rspec/rspec.xml --format progress -- ${TESTFILES}
+      - run:
+          name: Code Climate Test Coverage
+          command: ./cc-test-reporter format-coverage -t simplecov -o "coverage/codeclimate.$CIRCLE_NODE_INDEX.json"
+      - persist_to_workspace:
+          root: coverage
+          paths:
+            - codeclimate.*.json
       - run:
           name: Send test report to Code Climate
-          command: ./cc-test-reporter after-build --coverage-input-type simplecov --exit-code $?
+          command: |
+            ./cc-test-reporter sum-coverage --output - coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --input -
       - store_test_results:
-          path: /tmp/test-results
+          path: test-results
       - store_artifacts:
-          path: /tmp/test-results
-          destination: test-results
+          path: test-artifacts
 
 workflows:
   version: 2

--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
+--color
 --require spec_helper

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,17 +66,17 @@ RSpec.configure do |config|
   #   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
   #   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
   #   config.disable_monkey_patching!
-  #
-  #   # Many RSpec users commonly either run the entire suite or an individual
-  #   # file, and it's useful to allow more verbose output when running an
-  #   # individual spec file.
-  #   if config.files_to_run.one?
-  #     # Use the documentation formatter for detailed output,
-  #     # unless a formatter has already been configured
-  #     # (e.g. via a command-line flag).
-  #     config.default_formatter = "doc"
-  #   end
-  #
+
+  # Many RSpec users commonly either run the entire suite or an individual
+  # file, and it's useful to allow more verbose output when running an
+  # individual spec file.
+  if config.files_to_run.one?
+    # Use the documentation formatter for detailed output,
+    # unless a formatter has already been configured
+    # (e.g. via a command-line flag).
+    config.default_formatter = 'doc'
+  end
+
   #   # Print the 10 slowest examples and example groups at the
   #   # end of the spec run, to help surface which specs are running
   #   # particularly slow.


### PR DESCRIPTION
## Why was this change made?

In slack, jcoyne said:

> @Naomi Dushay something is really wrong with the coverage of was-registrar-app.
> It thinks FetchJob has 0% coverage, but it has a test: https://github.com/sul-dlss/was-registrar-app/blob/master/spec/jobs/fetch_job_spec.rb

Based on what I read, I believe this will work to get appropriate coverage showing in code climate.

## Was the documentation (README, DevOpsDocs, API, wiki, consul, etc.) updated?

n/a