### PR TITLE
missing stylesheets directory cannot precompile

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,3 @@
 //= link_tree ../images
 //= link_directory ../javascripts .js
-//= link_directory ../stylesheets .css
+// note:  we have none, otherwise this would be a link_directory: ../stylesheets .css


### PR DESCRIPTION
## Why was this change made?

App assets could not be built (e.g. as part of cap deploy) because we don't have an `app/assets/stylesheets` directory, because we don't have any stylesheets.

```
[ndushay@m3dl-sm-03-mbph-2 was-registrar-app (master)]$ bx rake assets:precompile
yarn install v1.17.3
[1/4] 🔍  Resolving packages...
success Already up-to-date.
✨  Done in 0.47s.
rake aborted!
Sprockets::ArgumentError: link_directory argument must be a directory
/Users/ndushay/sul-dlss-github/was-registrar-app/app/assets/config/manifest.js:3
Tasks: TOP => assets:precompile
(See full trace by running task with --trace)
```

## Was the documentation (README, DevOpsDocs, API, wiki, consul, etc.) updated?

n/a