### PR TITLE
Update to view_component 2.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem 'webpacker', '~> 4.0'
 
-gem 'actionview-component', '>= 1.14.0'
+gem 'view_component', '~> 2.0'
 # For configuration
 gem 'config', '~> 2.0'
 gem 'dor-services-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,8 +37,6 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    actionview-component (1.17.0)
-      capybara (~> 3)
     activejob (6.0.2.2)
       activesupport (= 6.0.2.2)
       globalid (>= 0.3.6)
@@ -353,6 +351,8 @@ GEM
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.1)
+    view_component (2.1.0)
+      capybara (~> 3)
     web-console (4.0.1)
       actionview (>= 6.0.0)
       activemodel (>= 6.0.0)
@@ -375,7 +375,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  actionview-component (>= 1.14.0)
   bootsnap (>= 1.1.0)
   byebug
   capistrano-passenger
@@ -401,6 +400,7 @@ DEPENDENCIES
   simplecov (~> 0.17.1)
   spring
   spring-watcher-listen (~> 2.0.0)
+  view_component (~> 2.0)
   web-console (>= 3.3.0)
   webpacker (~> 4.0)
   whenever (~> 1.0)


### PR DESCRIPTION


## Why was this change made?

actionview-component was renamed to view_component

## Was the documentation (README, DevOpsDocs, API, wiki, consul, etc.) updated?

no

## Does this change affect how this application integrates with other services?
no
If so, please confirm change was tested on stage and/or test added to sul-dlss/infrastructure-integration-test.
