### PR TITLE
Pin dlss-capistrano to 3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,5 +64,5 @@ group :deployment do
   gem 'capistrano-passenger'
   gem 'capistrano-rails'
   gem 'capistrano-sidekiq'
-  gem 'dlss-capistrano'
+  gem 'dlss-capistrano', '~> 3.5'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,7 +382,7 @@ DEPENDENCIES
   capistrano-sidekiq
   capybara
   config (~> 2.0)
-  dlss-capistrano
+  dlss-capistrano (~> 3.5)
   dor-services-client (~> 5.1)
   dor-workflow-client (~> 3.4, >= 3.4.2)
   factory_bot_rails


### PR DESCRIPTION
Do this because when dlss-capistrano 4.0 comes out, codebases that use both dlss-capistrano and capistrano-sidekiq without pinning the former will find it clobbering the sidekiq tasks from the latter, and that will cause confusion and woe.
