### PR TITLE
Upgrade to sidekiq 6 and dlss-capistrano 3.6 (to manage sidekiq)

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -14,7 +14,6 @@ require 'capistrano/honeybadger'
 require 'capistrano/passenger'
 require 'capistrano/rails'
 require 'dlss/capistrano'
-require 'capistrano/sidekiq'
 require 'whenever/capistrano'
 
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.

--- a/Gemfile
+++ b/Gemfile
@@ -32,8 +32,7 @@ gem 'dor-workflow-client', '~> 3.4', '>= 3.4.2'
 gem 'honeybadger'
 gem 'okcomputer'
 
-# TODO: Unpin from 5.x once we have switched to using systemd to manage the sidekiq daemon
-gem 'sidekiq', '~> 5.2'
+gem 'sidekiq', '~> 6.0'
 gem 'simple_form'
 gem 'whenever', '~> 1.0', require: false
 
@@ -63,6 +62,5 @@ end
 group :deployment do
   gem 'capistrano-passenger'
   gem 'capistrano-rails'
-  gem 'capistrano-sidekiq'
-  gem 'dlss-capistrano', '~> 3.5'
+  gem 'dlss-capistrano', '~> 3.6'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,9 +88,6 @@ GEM
       capistrano (~> 3.1)
       capistrano-bundler (~> 1.1)
     capistrano-shared_configs (0.2.2)
-    capistrano-sidekiq (1.0.3)
-      capistrano (>= 3.9.0)
-      sidekiq (>= 3.4, < 6.0)
     capybara (3.32.2)
       addressable
       mini_mime (>= 0.1.3)
@@ -246,7 +243,7 @@ GEM
     psych (3.1.0)
     public_suffix (4.0.5)
     puma (3.12.4)
-    rack (2.0.9)
+    rack (2.2.2)
     rack-protection (2.0.8.1)
       rack
     rack-proxy (0.6.5)
@@ -317,11 +314,11 @@ GEM
       i18n
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
-    sidekiq (5.2.8)
-      connection_pool (~> 2.2, >= 2.2.2)
-      rack (< 2.1.0)
-      rack-protection (>= 1.5.0)
-      redis (>= 3.3.5, < 5)
+    sidekiq (6.0.7)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      rack-protection (>= 2.0.0)
+      redis (>= 4.1.0)
     simple_form (5.0.2)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -377,10 +374,9 @@ DEPENDENCIES
   byebug
   capistrano-passenger
   capistrano-rails
-  capistrano-sidekiq
   capybara
   config (~> 2.0)
-  dlss-capistrano (~> 3.5)
+  dlss-capistrano (~> 3.6)
   dor-services-client (~> 6.0)
   dor-workflow-client (~> 3.4, >= 3.4.2)
   factory_bot_rails
@@ -393,7 +389,7 @@ DEPENDENCIES
   rspec-rails (~> 3.8)
   rspec_junit_formatter
   rubocop
-  sidekiq (~> 5.2)
+  sidekiq (~> 6.0)
   simple_form
   simplecov (~> 0.17.1)
   spring

--- a/config/deploy/prod.rb
+++ b/config/deploy/prod.rb
@@ -3,5 +3,3 @@
 server 'was-registrar-app.stanford.edu', user: 'was', roles: %w[web app db]
 
 Capistrano::OneTimeKey.generate_one_time_key!
-set :rails_env, 'production'
-set :bundle_without, %w[deployment test development].join(' ')

--- a/config/deploy/stage.rb
+++ b/config/deploy/stage.rb
@@ -3,5 +3,3 @@
 server 'was-registrar-app-stage.stanford.edu', user: 'was', roles: %w[web app db]
 
 Capistrano::OneTimeKey.generate_one_time_key!
-set :rails_env, 'production'
-set :bundle_without, %w[deployment test development].join(' ')


### PR DESCRIPTION
## Why was this change made?

Consistency with the rest of our portfolio; keeping pace with dependency updates; ability to upgrade rack to pick up security patches.

## How was this change tested?

Deployed to stage and prod to ensure # of workers stayed at 1, with just the 1 thread.

## Which documentation and/or configurations were updated?

None needed, AFAIK.