### PR TITLE
Update references from master to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WAS Registrar App
 
-[![CircleCI](https://circleci.com/gh/sul-dlss/was-registrar-app/tree/master.svg?style=svg)](https://circleci.com/gh/sul-dlss/was-registrar-app/tree/master)
+[![CircleCI](https://circleci.com/gh/sul-dlss/was-registrar-app/tree/main.svg?style=svg)](https://circleci.com/gh/sul-dlss/was-registrar-app/tree/main)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/825ca3f3c2fe04d3319c/test_coverage)](https://codeclimate.com/github/sul-dlss/was-registrar-app/test_coverage)
 [![Maintainability](https://api.codeclimate.com/v1/badges/825ca3f3c2fe04d3319c/maintainability)](https://codeclimate.com/github/sul-dlss/was-registrar-app/maintainability)
 
@@ -69,7 +69,7 @@ Background processing is performed by [Sidekiq](https://github.com/mperham/sidek
 
 Sidekiq can be monitored from [/queues](http://localhost:3000/queues).
 
-For more information on configuring and deploying Sidekiq, see this [doc](https://github.com/sul-dlss/DevOpsDocs/blob/master/projects/sul-requests/background_jobs.md).
+For more information on configuring and deploying Sidekiq, see this [doc](https://github.com/sul-dlss/DevOpsDocs/blob/main/projects/sul-requests/background_jobs.md).
 
 To run a Sidekiq worker locally:
 ```

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -3,7 +3,7 @@
 set :application, 'was_registrar_app'
 set :repo_url, 'https://github.com/sul-dlss/was-registrar-app.git'
 
-# Default branch is :master
+# Default branch is :main
 ask :branch, proc { `git rev-parse --abbrev-ref HEAD`.chomp }.call
 
 # Default deploy_to directory is /var/www/my_app


### PR DESCRIPTION
## Why was this change made?

Updates references to the new default branch: `main`


## How was this change tested?



## Which documentation and/or configurations were updated?



