### PR TITLE
Make download value explicit instead of relying on default.

### DIFF
--- a/app/jobs/fetch_job.rb
+++ b/app/jobs/fetch_job.rb
@@ -63,7 +63,7 @@ class FetchJob < ApplicationJob
     register_params = { type: 'http://cocina.sul.stanford.edu/models/webarchive-binary.jsonld',
                         label: fetch_month.job_directory,
                         version: 1,
-                        access: { access: 'dark' },
+                        access: { access: 'dark', download: 'none' },
                         administrative: { hasAdminPolicy: fetch_month.collection.admin_policy },
                         identification: { sourceId: source_id },
                         structural: { isMemberOf: [fetch_month.collection.druid] } }


### PR DESCRIPTION
## Why was this change made?
Explicit is clearer.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


