### PR TITLE
Upgrade the base docker image to a supported version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7.1-stretch
+FROM ruby:2.7
 
 # https://github.com/nodesource/distributions#installation-instructions
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \


### PR DESCRIPTION


## Why was this change made?

The old version is no longer available

## How was this change tested?



## Which documentation and/or configurations were updated?



