### PR TITLE
Skip yarn integrity check

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -53,7 +53,7 @@ development:
   compile: true
 
   # Verifies that correct packages and versions are installed by inspecting package.json, yarn.lock, and node_modules
-  check_yarn_integrity: true
+  check_yarn_integrity: false
 
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:


### PR DESCRIPTION
When running `docker-compose up web` we get this error:
```
warning Integrity check: System parameters don't match
```
I believe this happens when we move the yarn.lock from macos to linux (docker)

Skipping the integrity check allows us to carry on.

See https://github.com/sul-dlss/argo/pull/1634

## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



