### PR TITLE
Remove unused dependency serialize-javascript

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "jquery": "^3.4.1",
     "popper.js": "^1.15.0",
     "sass": "^1.42.1",
-    "serialize-javascript": "^2.1.1",
     "simple-datatables": "^2.1.6"
   },
   "devDependencies": {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -226,11 +226,6 @@ sass@^1.42.1:
   dependencies:
     chokidar ">=3.0.0 <4.0.0"
 
-serialize-javascript@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-2.1.2.tgz#ecec53b0e0317bdc95ef76ab7074b7384785fa61"
-  integrity sha512-rs9OggEUF0V4jUSecXazOYsLfu7OGK2qIn3c7IPBiffz32XniEp/TX9Xmc9LQfK2nQ2QKHvZ2oygKUGU0lG4jQ==
-
 simple-datatables@^2.1.6:
   version "2.1.13"
   resolved "https://registry.yarnpkg.com/simple-datatables/-/simple-datatables-2.1.13.tgz#7285653892cff37ead3ce8429559346b2d21446a"


### PR DESCRIPTION


## Why was this change made?
We don't use this library. 
Was added in https://github.com/sul-dlss/was-registrar-app/pull/185

## How was this change tested?



## Which documentation and/or configurations were updated?



