### PR TITLE
There is no need to require view_components explicity

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -3,7 +3,6 @@
 require_relative 'boot'
 
 require 'rails/all'
-require 'view_component/engine'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.


### PR DESCRIPTION


## Why was this change made?
doing so raises a deprecation warning


## How was this change tested?



## Which documentation and/or configurations were updated?



