### PR TITLE
simplecov no longer needs version restriction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,8 +49,7 @@ group :development, :test do
   gem 'rubocop'
   gem 'rubocop-rails'
   gem 'rubocop-rspec'
-  # Codeclimate is not compatible with 0.18+. See https://github.com/codeclimate/test-reporter/issues/413
-  gem 'simplecov', '~> 0.17.1'
+  gem 'simplecov'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,7 +214,6 @@ GEM
     ice_nine (0.11.2)
     jsbundling-rails (1.0.0)
       railties (>= 6.0.0)
-    json (2.6.1)
     listen (3.7.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -336,11 +335,12 @@ GEM
     simple_form (5.1.0)
       actionpack (>= 5.2)
       activemodel (>= 5.2)
-    simplecov (0.17.1)
+    simplecov (0.21.2)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.3)
     spring (2.1.1)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
@@ -403,7 +403,7 @@ DEPENDENCIES
   rubocop-rspec
   sidekiq (~> 6.0)
   simple_form
-  simplecov (~> 0.17.1)
+  simplecov
   spring
   view_component (~> 2.0)
   web-console (>= 4.1.0)


### PR DESCRIPTION
## Why was this change made?

Partly because I forgot to pull main ...

- no longer need to restrict simplecov gem.

## How was this change tested?



## Which documentation and/or configurations were updated?



