### PR TITLE
Set correct queue name prefix.

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,7 +63,7 @@ Rails.application.configure do
   # Use a real queuing backend for Active Job (and separate queues per environment).
   config.active_job.queue_adapter = :sidekiq
   # config.active_job.queue_adapter     = :resque
-  # config.active_job.queue_name_prefix = "was_registrar_app_production"
+  config.active_job.queue_name_prefix = 'was_registrar_app_production'
 
   config.action_mailer.perform_caching = false
 


### PR DESCRIPTION
## Why was this change made?
Jobs were getting added to the default queue, which has no workers.


## How was this change tested?



## Which documentation and/or configurations were updated?



