### PR TITLE
Use Rails 6.1 defaults

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,7 +11,7 @@ Bundler.require(*Rails.groups)
 module WasRegistrarApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.2
+    config.load_defaults 6.1
 
     # Configuration for the application, engines, and railties goes here.
     #


### PR DESCRIPTION

## Why was this change made?

This prevents deprecation errors like:
```
DEPRECATION WARNING: Non-URL-safe CSRF tokens are deprecated. Use 6.1 defaults or above. (called from <top (required)> at /Users/jcoyne85/workspace/sul-dlss/was-registrar-app/spec/rails_helper.rb:14)
DEPRECATION WARNING: Using legacy connection handling is deprecated. Please set
 to  in your application.
```

## How was this change tested?



## Which documentation and/or configurations were updated?



