### PR TITLE
Keep the tmp/pids directory in Git

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
 /node_modules
-/tmp
+/tmp/pids/server.pid
 /postgres-data
 /redis-data

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,11 @@
 !/log/.keep
 !/tmp/.keep
 
+# Ignore pidfiles, but keep the directory.
+/tmp/pids/*
+!/tmp/pids/
+!/tmp/pids/.keep
+
 # Ignore uploaded files in development
 /storage/*
 !/storage/.keep


### PR DESCRIPTION
## Why was this change made? 🤔

The web container won't start up without `tmp/pids`:

```
➜  was-registrar-app git:(main) docker compose up web
[+] Running 3/0
 ⠿ Container was-registrar-app-redis-1  Running                                                                 0.0s
 ⠿ Container was-registrar-app-db-1     Running                                                                 0.0s
 ⠿ Container was-registrar-app-web-1    Created                                                                 0.0s
Attaching to was-registrar-app-web-1
was-registrar-app-web-1  | Puma starting in single mode...
was-registrar-app-web-1  | * Puma version: 5.6.4 (ruby 3.0.4-p208) ("Birdie's Version")
was-registrar-app-web-1  | *  Min threads: 5
was-registrar-app-web-1  | *  Max threads: 5
was-registrar-app-web-1  | *  Environment: development
was-registrar-app-web-1  | *          PID: 7
was-registrar-app-web-1  | * Listening on http://0.0.0.0:3000
was-registrar-app-web-1  | /usr/local/bundle/gems/puma-5.6.4/lib/puma/launcher.rb:248:in `write': No such file or directory @ rb_sysopen - tmp/pids/server.pid (Errno::ENOENT)
was-registrar-app-web-1  | 	from /usr/local/bundle/gems/puma-5.6.4/lib/puma/launcher.rb:248:in `write_pid'
was-registrar-app-web-1  | 	from /usr/local/bundle/gems/puma-5.6.4/lib/puma/launcher.rb:112:in `write_state'
was-registrar-app-web-1  | 	from /usr/local/bundle/gems/puma-5.6.4/lib/puma/single.rb:48:in `run'
was-registrar-app-web-1  | 	from /usr/local/bundle/gems/puma-5.6.4/lib/puma/launcher.rb:182:in `run'
was-registrar-app-web-1  | 	from /usr/local/bundle/gems/puma-5.6.4/lib/puma/cli.rb:81:in `run'
was-registrar-app-web-1  | 	from /usr/local/bundle/gems/puma-5.6.4/bin/puma:10:in `<top (required)>'
was-registrar-app-web-1  | 	from /usr/local/bundle/bin/puma:25:in `load'
was-registrar-app-web-1  | 	from /usr/local/bundle/bin/puma:25:in `<main>'
was-registrar-app-web-1 exited with code 1
```

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning (and maybe even SWAP system?) works properly in [stage|qa] environment, in addition to specs. ⚡


