### PR TITLE
Unpin redis docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     volumes:
       - postgres-data:/var/lib/postgresql/data
   redis:
-    image: redis:3
+    image: redis
     command: redis-server
     ports:
       - 6379:6379


### PR DESCRIPTION
## Why was this change made? 🤔
Not use deprecated redis version in dev

## How was this change tested? 🤨
running specs, bringing up containers and confirming no errors

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning (and maybe even SWAP system?) works properly in [stage|qa] environment, in addition to specs. ⚡


