### PR TITLE
Uses alpine base image and updates docker config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,18 @@
-FROM ruby:3.0
+FROM ruby:3.0-alpine
 
-# https://github.com/nodesource/distributions#installation-instructions
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - \
-    && apt-get install -y nodejs
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-RUN apt-get update -qq && \
-    apt-get install -y nano build-essential postgresql-client yarn
+RUN apk add --update --no-cache \
+  build-base \
+  postgresql-dev \
+  postgresql-client \
+  tzdata \
+  yarn
 
 WORKDIR /app
 
-ADD Gemfile Gemfile.lock package.json yarn.lock /app/
-
-ENV BUNDLER_VERSION 2.3.4
+COPY Gemfile Gemfile.lock /app/
 RUN gem install bundler && bundle install
+
+COPY package.json yarn.lock /app/
 RUN yarn install --check-files
 COPY . .
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - POSTGRES_HOST=db
       - REDIS_URL=redis://redis:6379/1
       - RAILS_ENV=development
+    volumes:
+      - ./:/app
     depends_on:
       - db
       - redis


### PR DESCRIPTION
## Why was this change made? 🤔

Makes app easier to use for development, using a volume with the code. Switches to using alpine version of base image and reduces image size from 1.46GB to 1.06GB. Removes specifying older bundler version. 

## How was this change tested? 🤨
Running locally

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning (and maybe even SWAP system?) works properly in [stage|qa] environment, in addition to specs. ⚡


