### PR TITLE
Invoke honeybadger deployment cap task under RVM

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -432,4 +432,4 @@ DEPENDENCIES
   whenever (~> 1.0)
 
 BUNDLED WITH
-   2.3.9
+   2.3.14

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -42,6 +42,9 @@ set :sidekiq_systemd_use_hooks, true
 # honeybadger_env otherwise defaults to rails_env
 set :honeybadger_env, fetch(:stage)
 
+# doesn't appear to do so on our new Ubuntu boxes :shrug:
+set :rvm_map_bins, fetch(:rvm_map_bins, []).push('honeybadger')
+
 # update shared_configs before restarting app
 before 'deploy:restart', 'shared_configs:update'
 


### PR DESCRIPTION
## Why was this change made? 🤔

To successfully register HB deployments. This is a known situation on some of our Ubuntu boxes.

## How was this change tested? 🤨

Before this change, I deployed to QA and the honeybadger:deploy step failed. After, it passed.
