### PR TITLE
Update README wasapi-downloader version to download

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ docker-compose up -d redis
 Note: The WASAPI Downloader is not typically needed for development; it is necessary for running fetches.
 
 ```
-curl -L https://github.com/sul-dlss/wasapi-downloader/releases/download/v1.1.0/wasapi-downloader.zip > wasapi-downloader.zip
+curl -L https://github.com/sul-dlss/wasapi-downloader/releases/download/v1.1.1/wasapi-downloader.zip > wasapi-downloader.zip
 unzip wasapi-downloader.zip
 ```
 If installing in a different location, make the appropriate change in settings.


### PR DESCRIPTION
## Why was this change made? 🤔

Need wasapi-downloader version 1.1.1 to get bug fix.

## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning (and maybe even SWAP system?) works properly in [stage|qa] environment, in addition to specs. ⚡


