### PR TITLE
Remove capistrano-rvm and other bits added to help deploy to ubuntu boxes

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -13,7 +13,6 @@ require 'capistrano/bundler'
 require 'capistrano/honeybadger'
 require 'capistrano/passenger'
 require 'capistrano/rails'
-require 'capistrano/rvm'
 require 'dlss/capistrano'
 require 'whenever/capistrano'
 

--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,5 @@ end
 group :deployment do
   gem 'capistrano-passenger'
   gem 'capistrano-rails'
-  gem 'capistrano-rvm', require: false
   gem 'dlss-capistrano', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,9 +98,6 @@ GEM
     capistrano-rails (1.6.2)
       capistrano (~> 3.1)
       capistrano-bundler (>= 1.1, < 3)
-    capistrano-rvm (0.1.2)
-      capistrano (~> 3.0)
-      sshkit (~> 1.2)
     capistrano-shared_configs (0.2.2)
     capybara (3.37.1)
       addressable
@@ -403,7 +400,6 @@ DEPENDENCIES
   byebug
   capistrano-passenger
   capistrano-rails
-  capistrano-rvm
   capybara
   config (~> 2.0)
   cssbundling-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,7 +135,7 @@ GEM
       activesupport
     diff-lcs (1.5.0)
     digest (3.1.0)
-    dlss-capistrano (4.1.1)
+    dlss-capistrano (4.1.2)
       capistrano (~> 3.0)
       capistrano-bundle_audit (>= 0.3.0)
       capistrano-one_time_key

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -42,9 +42,6 @@ set :sidekiq_systemd_use_hooks, true
 # honeybadger_env otherwise defaults to rails_env
 set :honeybadger_env, fetch(:stage)
 
-# doesn't appear to do so on our new Ubuntu boxes :shrug:
-set :rvm_map_bins, fetch(:rvm_map_bins, []).push('honeybadger')
-
 # update shared_configs before restarting app
 before 'deploy:restart', 'shared_configs:update'
 


### PR DESCRIPTION
## Why was this change made? 🤔

We are testing handling this via puppet instead, by ensuring a default system bashrc is executed, which will take care of RVM bootstrapping.



## How was this change tested? 🤨

CI + QA
