### PR TITLE
[HOLD] Provide title when registering.

### DIFF
--- a/app/jobs/fetch_job.rb
+++ b/app/jobs/fetch_job.rb
@@ -60,17 +60,21 @@ class FetchJob < ApplicationJob
   end
 
   def register
-    register_params = { type: Cocina::Models::ObjectType.webarchive_binary,
-                        label: fetch_month.job_directory,
-                        version: 1,
-                        access: { view: 'citation-only', download: 'none' },
-                        administrative: { hasAdminPolicy: fetch_month.collection.admin_policy },
-                        identification: { sourceId: source_id },
-                        structural: { isMemberOf: [fetch_month.collection.druid] } }
     request_model = Cocina::Models::RequestDRO.new(register_params)
     response_model = dor_services_client.objects.register(params: request_model)
 
     response_model.externalIdentifier
+  end
+
+  def register_params
+    { type: Cocina::Models::ObjectType.webarchive_binary,
+      label: fetch_month.job_directory,
+      version: 1,
+      description: { title: [{ value: fetch_month.job_directory }] },
+      access: { view: 'citation-only', download: 'none' },
+      administrative: { hasAdminPolicy: fetch_month.collection.admin_policy },
+      identification: { sourceId: source_id },
+      structural: { isMemberOf: [fetch_month.collection.druid] } }
   end
 
   def start_workflow(druid)

--- a/spec/jobs/fetch_job_spec.rb
+++ b/spec/jobs/fetch_job_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe FetchJob do
         Cocina::Models::RequestDRO.new({ type: Cocina::Models::ObjectType.webarchive_binary,
                                          label: 'AIT_915/2017_11',
                                          version: 1,
+                                         description: { title: [{ value: 'AIT_915/2017_11' }] },
                                          access: { view: 'citation-only', download: 'none' },
                                          administrative: { hasAdminPolicy: 'druid:yf700yh0557' },
                                          identification: { sourceId: 'sul:ait-915-2017_11' },


### PR DESCRIPTION
closes #440

## Why was this change made? 🤔
To allow removing a workflow step.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning (and maybe even SWAP system?) works properly in [stage|qa] environment, in addition to specs. ⚡

Unit

HOLD so that can be coupled with removing workflow step.