### PR TITLE
Support retry fetches.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,11 @@ Metrics/MethodLength:
   Exclude:
     - db/migrate/*
 
+RSpec/LetSetup:
+  Exclude:
+    - spec/services/fetch_job_retrier_spec.rb
+    - spec/features/retry_fetches_spec.rb
+    
 Gemspec/DateAssignment: # new in 1.10
   Enabled: true
 Gemspec/RequireMFA: # new in 1.23

--- a/app/components/actions_component.html.erb
+++ b/app/components/actions_component.html.erb
@@ -1,0 +1,4 @@
+<%= button_to("Queue fetch jobs", [:fetch, @collection], method: :post, class: 'btn btn-primary mb-2') %>
+<% if retry? %>
+  <%= button_to("Retry fetch jobs", [:retry, @collection], method: :post, class: 'btn btn-primary') %>
+<% end %>

--- a/app/components/actions_component.rb
+++ b/app/components/actions_component.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Actions for a FetchMonth.
+class ActionsComponent < ViewComponent::Base
+  def initialize(collection:)
+    super
+    @collection = collection
+  end
+
+  def retry?
+    FetchJobRetrier.retry?(collection: @collection)
+  end
+end

--- a/app/services/fetch_job_retrier.rb
+++ b/app/services/fetch_job_retrier.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Supports retrying fetches for FetchMonths.
+# Retrying is performed for FetchMonths that are after the last FetchMonth that resulted in
+# registration of an item and have a stateus of success or failure.
+class FetchJobRetrier
+  # @return [boolean] true if there are fetch months that can be retried.
+  def self.retry?(collection:)
+    new(collection.id).retry?
+  end
+
+  # Requeues FetchMonths that can be retried.
+  def self.retry(collection:)
+    new(collection.id).retry
+  end
+
+  def initialize(collection_id)
+    @collection_id = collection_id
+  end
+
+  def retry?
+    retriable_fetch_months.exists?
+  end
+
+  def retry
+    retriable_fetch_months.each do |fetch_month|
+      fetch_month.update(status: 'waiting', failure_reason: nil)
+      FetchJob.perform_later(fetch_month)
+    end
+  end
+
+  private
+
+  attr_reader :collection_id
+
+  def last_registered_fetch_month
+    @last_registered_fetch_month ||= FetchMonth
+                                     .where(collection_id: collection_id)
+                                     .where(status: 'success')
+                                     .where.not(crawl_item_druid: nil).order(id: :desc)
+                                     .limit(1)
+                                     .first
+  end
+
+  def retriable_fetch_months
+    @retriable_fetch_months ||= begin
+      fetch_months = FetchMonth.where(collection_id: collection_id, status: %w[success failure])
+      last_registered_fetch_month ? fetch_months.where('id > ?', last_registered_fetch_month.id) : fetch_months
+    end
+  end
+end

--- a/app/views/collections/edit.html.erb
+++ b/app/views/collections/edit.html.erb
@@ -5,7 +5,7 @@
 <div class="card" style="margin-top: 20px">
   <div class="card-header">Actions</div>
   <div class="card-body">
-    <a class="btn btn-primary" href="<%= url_for([:fetch, @collection]) %>" role="button">Queue fetch jobs</a>
+    <%= render(ActionsComponent.new(collection: @collection)) %>
   </div>
 </div>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,8 @@ Rails.application.routes.draw do
   get '/', to: redirect('/collections')
 
   resources :collections, except: %i[destroy show] do
-    get 'fetch', on: :member
+    post 'fetch', on: :member
+    post 'retry', on: :member
   end
 
   mount Sidekiq::Web => '/queues'

--- a/spec/factories/fetch_months.rb
+++ b/spec/factories/fetch_months.rb
@@ -2,7 +2,7 @@
 
 FactoryBot.define do
   factory :fetch_month do
-    year { 2017 }
+    sequence(:year, 2020)
     month { 11 }
     status { 'waiting' }
   end

--- a/spec/features/queue_fetches_spec.rb
+++ b/spec/features/queue_fetches_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe 'Queue fetch jobs for a collection', type: :feature do
     click_link collection.title
     expect(page).to have_content 'Edit'
 
-    click_link 'Queue fetch jobs'
+    click_button 'Queue fetch jobs'
     expect(FetchJobCreator).to have_received(:run).with(collection: collection)
-    expect(page).to have_content 'Queued fetch jobs for this collection.'
+    expect(page).to have_content 'Queued new fetch jobs.'
   end
 end

--- a/spec/features/retry_fetches_spec.rb
+++ b/spec/features/retry_fetches_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Retry fetches', type: :feature do
+  let(:collection) { create(:collection) }
+
+  context 'when no retriable fetch months' do
+    it 'does not render button' do
+      visit edit_collection_path(collection)
+      expect(page).to have_content "Edit #{collection.title}"
+      expect(page).to have_button 'Queue fetch jobs'
+      expect(page).not_to have_button 'Retry fetch jobs'
+    end
+  end
+
+  context 'when retriable fetch months' do
+    let!(:fetch_month) { create(:fetch_month, collection: collection, status: 'success') }
+
+    before do
+      allow(FetchJobRetrier).to receive(:retry)
+    end
+
+    it 'allows retrying' do
+      visit edit_collection_path(collection)
+      expect(page).to have_content "Edit #{collection.title}"
+
+      click_button 'Retry fetch jobs'
+
+      expect(page).to have_content "Edit #{collection.title}"
+      expect(page).to have_content 'Queued retry fetch jobs.'
+      expect(FetchJobRetrier).to have_received(:retry).with(collection: collection)
+    end
+  end
+end

--- a/spec/jobs/fetch_job_spec.rb
+++ b/spec/jobs/fetch_job_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe FetchJob do
   let(:collection) { create(:collection, admin_policy: 'druid:yf700yh0557', wasapi_collection_id: '915') }
-  let(:fetch_month) { create(:fetch_month, collection: collection) }
+  let(:fetch_month) { create(:fetch_month, collection: collection, year: 2017) }
 
   describe '#perform_now' do
     let(:stderr) { nil }

--- a/spec/models/fetch_month_spec.rb
+++ b/spec/models/fetch_month_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe FetchMonth, type: :model do
   let(:collection) { create(:collection, wasapi_collection_id: '915') }
-  let(:fetch_month) { create(:fetch_month, collection: collection, crawl_item_druid: 'druid:abc123') }
+  let(:fetch_month) { create(:fetch_month, collection: collection, crawl_item_druid: 'druid:abc123', year: 2017) }
 
   describe '#crawl_directory' do
     it 'returns the correct crawl directory' do
@@ -18,7 +18,7 @@ RSpec.describe FetchMonth, type: :model do
     end
 
     context 'when the month is a single digit' do
-      let(:fetch_month) { create(:fetch_month, collection: collection, month: 1) }
+      let(:fetch_month) { create(:fetch_month, collection: collection, month: 1, year: 2017) }
 
       it 'returns the correct job directory with month padded' do
         expect(fetch_month.job_directory).to eq('AIT_915/2017_01')

--- a/spec/services/fetch_job_retrier_spec.rb
+++ b/spec/services/fetch_job_retrier_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe FetchJobRetrier do
+  let(:retrier) { described_class.new(collection.id) }
+
+  let(:collection) { create(:collection, wasapi_collection_id: '915') }
+
+  before do
+    allow(FetchJob).to receive(:perform_later)
+  end
+
+  context 'when no fetch months' do
+    it 'does not have retriable months' do
+      expect(retrier.retry?).to be false
+    end
+
+    it 'does not retry' do
+      retrier.retry
+      expect(FetchJob).not_to have_received(:perform_later)
+    end
+  end
+
+  context 'when no last registered fetch month' do
+    let!(:success_fetch_month) { create(:fetch_month, collection: collection, status: 'success') }
+    let!(:failure_fetch_month) { create(:fetch_month, collection: collection, status: 'failure') }
+    let!(:waiting_fetch_month) { create(:fetch_month, collection: collection, status: 'waiting') }
+    let!(:running_fetch_month) { create(:fetch_month, collection: collection, status: 'waiting') }
+
+    it 'has retriable months' do
+      expect(retrier.retry?).to be true
+    end
+
+    it 'retries retriable months' do
+      retrier.retry
+      expect(FetchJob).not_to have_received(:perform_later).with([success_fetch_month, failure_fetch_month])
+    end
+  end
+
+  context 'when last registered fetch month' do
+    let!(:previous_success_fetch_month) { create(:fetch_month, collection: collection, status: 'success') }
+    let!(:last_registered_fetch_month) do
+      create(:fetch_month, collection: collection, status: 'success', crawl_item_druid: 'druid:abc123')
+    end
+    let!(:success_fetch_month) { create(:fetch_month, collection: collection, status: 'success') }
+    let!(:failure_fetch_month) { create(:fetch_month, collection: collection, status: 'failure') }
+    let!(:waiting_fetch_month) { create(:fetch_month, collection: collection, status: 'waiting') }
+    let!(:running_fetch_month) { create(:fetch_month, collection: collection, status: 'waiting') }
+
+    it 'has retriable months' do
+      expect(retrier.retry?).to be true
+    end
+
+    it 'retries retriable months' do
+      retrier.retry
+      expect(FetchJob).not_to have_received(:perform_later).with([success_fetch_month, failure_fetch_month])
+    end
+  end
+end


### PR DESCRIPTION
closes #437

## Why was this change made? 🤔
So that user can retry fetches without needing dev assistance.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning (and maybe even SWAP system?) works properly in [stage|qa] environment, in addition to specs. ⚡

Unit

![image](https://user-images.githubusercontent.com/588335/171408684-eb6258c5-59ef-4a82-b1e3-d4c59e80f7c2.png)

