### PR TITLE
Strips whitespace from collection form and validates collection druid.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,8 @@ gem 'jsbundling-rails'
 gem 'stimulus-rails'
 
 gem 'view_component', '~> 2.0'
+
+gem 'auto_strip_attributes'
 # For configuration
 gem 'config', '~> 2.0'
 gem 'dor-services-client', '~> 12.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,6 +72,8 @@ GEM
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.2)
     attr_extras (6.2.5)
+    auto_strip_attributes (2.6.0)
+      activerecord (>= 4.0)
     bindex (0.8.1)
     bootsnap (1.12.0)
       msgpack (~> 1.2)
@@ -400,6 +402,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  auto_strip_attributes
   bootsnap (>= 1.1.0)
   byebug
   capistrano-passenger

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -5,12 +5,15 @@ class Collection < ApplicationRecord
   has_many :fetch_months
   scope :active, -> { where(active: true) }
 
+  # Removes extra spaces
+  auto_strip_attributes :title, :druid, :wasapi_collection_id
+
   validates_presence_of :title, :druid, :embargo_months, :fetch_start_month, :wasapi_provider_account,
                         :wasapi_collection_id
   validates :active, inclusion: { in: [true, false] }
   validates :admin_policy, inclusion: { in: %w[druid:wr005wn5739 druid:yf700yh0557] }
-  validates :druid, format: { with: /druid:.+/,
-                              message: 'must begin with druid:' }
+  validates :druid, format: { with: /\Adruid:[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}\z/,
+                              message: 'must be a valid druid beginning with druid:' }, collection_druid: true
   validates_uniqueness_of :wasapi_collection_id,
                           scope: %i[wasapi_provider wasapi_account],
                           message: 'already have a collection configured for this WASAPI collection'

--- a/app/validators/collection_druid_validator.rb
+++ b/app/validators/collection_druid_validator.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# Validates that collection exists.
+class CollectionDruidValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return unless Settings.validate_collection_druid
+    # If there are already errors, the return.
+    # This prevents an invalid druid from causing find from failing with an OpenAPI error.
+    return if record.errors[attribute].present?
+
+    cocina_obj = dor_services_client.object(value).find
+    record.errors.add attribute, 'not a collection' unless cocina_obj.collection?
+  rescue Dor::Services::Client::NotFoundResponse
+    record.errors.add attribute, 'does not exist'
+  end
+
+  private
+
+  def dor_services_client
+    @dor_services_client ||= Dor::Services::Client.configure(url: Settings.dor_services.url,
+                                                             token: Settings.dor_services.token)
+  end
+end

--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -1,4 +1,4 @@
-<%= simple_form_for @collection do |form| %>
+<%= simple_form_for @collection, data: { turbo: false } do |form| %>
   <div class="card">
     <div class="card-header">Collection</div>
     <div class="card-body">
@@ -15,8 +15,8 @@
           ['Web Archive Crawl Object Dark APO', 'druid:yf700yh0557']
         ] %>
       <%= form.input :active %>
-      <%= form.button :submit, class: 'btn-primary' %>
-      <%= link_to 'Cancel', collections_path, style: "margin-left: 25px" %>
+      <%= form.button :submit, class: 'btn-primary mt-2' %>
+      <%= link_to 'Cancel', collections_path, class: 'ms-2' %>
     </div>
   </div>
 <% end %>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -11,3 +11,5 @@ dor_services:
   token: secret-token
 
 argo_view_url: https://argo.stanford.edu/view/%s
+
+validate_collection_druid: true

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -20,3 +20,4 @@ wasapi_providers:
         password: pass
 crawl_directory: tmp/jobs
 wasapi_downloader_bin: wasapi-downloader/bin/wasapi-downloader
+validate_collection_druid: false

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -20,3 +20,4 @@ wasapi_providers:
         password: pass
 crawl_directory: tmp/jobs
 wasapi_downloader_bin: wasapi-downloader/bin/wasapi-downloader
+validate_collection_druid: false

--- a/spec/features/create_collection_spec.rb
+++ b/spec/features/create_collection_spec.rb
@@ -14,18 +14,18 @@ RSpec.describe 'Create a collection', type: :feature do
       click_button 'Create Collection'
 
       expect(page).to have_content "Title can't be blank"
-      expect(page).to have_content "Druid can't be blank and Druid must begin with druid:"
+      expect(page).to have_content "Druid can't be blank and Druid must be a valid druid beginning with druid:"
       expect(page).to have_content "Wasapi provider account can't be blank"
     end
   end
 
   context 'when all fields are present' do
-    it 'shows the errors' do
+    it 'creates the collection' do
       visit collections_path
       click_link 'Add a Collection'
 
-      fill_in 'Title', with: 'Robots'
-      fill_in 'Druid', with: "druid:#{rand(10_000)}"
+      fill_in 'Title', with: ' Robots ' # Intentionally has extra spaces to test stripping
+      fill_in 'Druid', with: 'druid:dm081mp8068'
       select 'August', from: 'collection_fetch_start_month_2i'
       select '2011', from: 'collection_fetch_start_month_1i'
       select 'Archive-It (ait) > ua', from: 'WASAPI provider / account'
@@ -34,6 +34,7 @@ RSpec.describe 'Create a collection', type: :feature do
       click_button 'Create Collection'
 
       expect(page).to have_content 'Collection created.'
+      expect(Collection.exists?(title: 'Robots')).to be true
     end
   end
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe Collection, type: :model do
   let(:collection) do
-    build(:ar_collection, title: 'My collection', druid: 'druid:abc123')
+    build(:ar_collection, title: 'My collection', druid: 'druid:dm081mp8068')
   end
 
   before do
@@ -23,7 +23,7 @@ RSpec.describe Collection, type: :model do
       expect(collection.valid?).to be(false)
     end
 
-    it 'validates druid' do
+    it 'validates druid must begin with druid' do
       collection.druid = 'abc123'
       expect(collection.valid?).to be(false)
     end
@@ -56,6 +56,52 @@ RSpec.describe Collection, type: :model do
     it 'validates unique' do
       collection.wasapi_collection_id = '916'
       expect(collection.valid?).to be(false)
+    end
+  end
+
+  context 'when validating druid' do
+    let(:object_client) { instance_double(Dor::Services::Client::Object) }
+
+    before do
+      allow(Settings).to receive(:validate_collection_druid).and_return(true)
+      allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+    end
+
+    context 'when druid found and a collection' do
+      let(:cocina_obj) { instance_double(Cocina::Models::Collection, collection?: true) }
+
+      before do
+        allow(object_client).to receive(:find).and_return(cocina_obj)
+      end
+
+      it 'is valid' do
+        expect(collection.valid?).to be(true)
+        expect(Dor::Services::Client).to have_received(:object).with('druid:dm081mp8068')
+      end
+    end
+
+    context 'when druid found and not a collection' do
+      let(:cocina_obj) { instance_double(Cocina::Models::DRO, collection?: false) }
+
+      before do
+        allow(object_client).to receive(:find).and_return(cocina_obj)
+      end
+
+      it 'is not valid' do
+        expect(collection.valid?).to be(false)
+        expect(collection.errors[:druid]).to eq(['not a collection'])
+      end
+    end
+
+    context 'when not found' do
+      before do
+        allow(object_client).to receive(:find).and_raise(Dor::Services::Client::NotFoundResponse)
+      end
+
+      it 'is not valid' do
+        expect(collection.valid?).to be(false)
+        expect(collection.errors[:druid]).to eq(['does not exist'])
+      end
     end
   end
 end


### PR DESCRIPTION
closes #309

## Why was this change made? 🤔
More resilient to user error.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning (and maybe even SWAP system?) works properly in [stage|qa] environment, in addition to specs. ⚡

Unit, qa

