### PR TITLE
Adds rake task for auditing WARCs.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ group :development, :test do
   gem 'rubocop-rails'
   gem 'rubocop-rspec'
   gem 'simplecov'
+  gem 'webmock'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -129,6 +129,8 @@ GEM
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
     connection_pool (2.2.5)
+    crack (0.4.5)
+      rexml
     crass (1.0.6)
     cssbundling-rails (1.1.0)
       railties (>= 6.0.0)
@@ -209,6 +211,7 @@ GEM
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    hashdiff (1.0.1)
     honeybadger (4.12.1)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
@@ -388,6 +391,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webmock (3.14.0)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -435,6 +442,7 @@ DEPENDENCIES
   turbo-rails
   view_component (~> 2.0)
   web-console (>= 4.1.0)
+  webmock
   whenever (~> 1.0)
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -95,3 +95,11 @@ bundle exec sidekiq
 To deploy to [stage](https://was-registrar-app-stage.stanford.edu): `bundle exec cap stage deploy`
 
 To deploy to [production](https://was-registrar-app.stanford.edu): `bundle exec cap prod deploy`
+
+## Auditing
+To audit the WARCs that have been accessioned in SDR against the WARCs available from a WASAPI provider,
+use the audit rake task: `bin/rake audit['<collection druid>']`
+
+For example: `RAILS_ENV=production bin/rake audit['druid:hw105qf0103']`
+
+This will return a list of WARC filenames that are available but have not been accessioned.

--- a/app/jobs/fetch_job.rb
+++ b/app/jobs/fetch_job.rb
@@ -54,18 +54,13 @@ class FetchJob < ApplicationJob
     @workflow_client ||= Dor::Workflow::Client.new(url: Settings.workflow.url)
   end
 
-  def dor_services_client
-    @dor_services_client ||= Dor::Services::Client.configure(url: Settings.dor_services.url,
-                                                             token: Settings.dor_services.token)
-  end
-
   def register
-    response_model = dor_services_client.objects.register(params: RequestBuilder.build(fetch_month: fetch_month))
+    response_model = Dor::Services::Client.objects.register(params: RequestBuilder.build(fetch_month: fetch_month))
     response_model.externalIdentifier
   end
 
   def start_workflow(druid)
-    current_version = dor_services_client.object(druid).version.current.to_i
+    current_version = Dor::Services::Client.object(druid).version.current.to_i
     workflow_client.create_workflow_by_name(druid, 'wasCrawlPreassemblyWF', version: current_version)
   end
 

--- a/app/services/audit/sdr_warc_lister.rb
+++ b/app/services/audit/sdr_warc_lister.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Audit
+  # Enumberable that returns WARC filenames for a collection from SDR.
+  class SdrWarcLister
+    include Enumerable
+    def initialize(collection_druid:)
+      @collection_druid = collection_druid
+    end
+
+    def each(&block)
+      if block_given?
+        member_druids.each do |member_druid|
+          files_for(member_druid).each { |file| block.call(file) }
+        end
+      else
+        to_enum(:each)
+      end
+    end
+
+    private
+
+    attr_reader :collection_druid
+
+    def member_druids
+      Dor::Services::Client.object(collection_druid).members.map(&:externalIdentifier)
+    end
+
+    def files_for(member_druid)
+      cocina_obj = Dor::Services::Client.object(member_druid).find
+      return [] if cocina_obj.type == Cocina::Models::ObjectType.webarchive_seed
+
+      cocina_obj.structural.contains.flat_map do |resource|
+        resource.structural.contains.map(&:filename)
+      end
+    end
+  end
+end

--- a/app/services/audit/warc_auditer.rb
+++ b/app/services/audit/warc_auditer.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Audit
+  # Audits accessioned WARCs against WARCs available from a WASAPI provider.
+  class WarcAuditer
+    # @return [Array<String>] filenames that are available from WASAPI provider but have not been accessioned
+    def self.audit(collection_druid:, wasapi_collection_id:, wasapi_account:, wasapi_provider: 'ait')
+      new(collection_druid: collection_druid, wasapi_collection_id: wasapi_collection_id,
+          wasapi_account: wasapi_account, wasapi_provider: wasapi_provider).audit
+    end
+
+    def initialize(collection_druid:, wasapi_collection_id:, wasapi_account:, wasapi_provider:)
+      @collection_druid = collection_druid
+      @wasapi_collection_id = wasapi_collection_id
+      @wasapi_account = wasapi_account
+      @wasapi_provider = wasapi_provider
+    end
+
+    def audit
+      wasapi_warc_filenames - sdr_warc_filenames
+    end
+
+    private
+
+    attr_reader :collection_druid, :wasapi_collection_id, :wasapi_account, :wasapi_provider
+
+    def wasapi_warc_filenames
+      WasapiWarcLister.new(wasapi_collection_id: wasapi_collection_id, wasapi_provider: wasapi_provider,
+                           wasapi_account: wasapi_account).to_a
+    end
+
+    def sdr_warc_filenames
+      SdrWarcLister.new(collection_druid: collection_druid).to_a
+    end
+  end
+end

--- a/app/services/audit/wasapi_warc_lister.rb
+++ b/app/services/audit/wasapi_warc_lister.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Audit
+  # Enumberable that returns WARC filenames for a collection from a WASAPI provider.
+  class WasapiWarcLister
+    include Enumerable
+    def initialize(wasapi_collection_id:, wasapi_provider:, wasapi_account:)
+      @wasapi_collection_id = wasapi_collection_id
+      @wasapi_provider = wasapi_provider
+      @wasapi_account = wasapi_account
+    end
+
+    def each(&block)
+      if block_given?
+        next_url = first_page_url
+        while next_url
+          response = get_page(next_url)
+          files_for(response).each { |file| block.call(file) }
+          next_url = response[:next]
+        end
+      else
+        to_enum(:each)
+      end
+    end
+
+    private
+
+    attr_reader :wasapi_collection_id, :wasapi_provider, :wasapi_account
+
+    def wasapi_provider_config
+      Settings.wasapi_providers[wasapi_provider]
+    end
+
+    def wasapi_account_config
+      wasapi_provider_config.accounts[wasapi_account]
+    end
+
+    def first_page_url
+      "#{wasapi_provider_config.baseurl}webdata?collection=#{wasapi_collection_id}"
+    end
+
+    def connection
+      @connection ||= Faraday.new do |conn|
+        conn.request :authorization, :basic, wasapi_account_config.username,
+                     wasapi_account_config.password
+      end
+    end
+
+    def get_page(url)
+      response = connection.get(url) do |request|
+        request.headers = { 'Content-Type' => 'application/json' }
+      end
+
+      raise "Getting #{url} returned #{response.status}" unless response.success?
+
+      JSON.parse(response.body).with_indifferent_access
+    end
+
+    def files_for(response)
+      response[:files].pluck(:filename)
+    end
+  end
+end

--- a/app/validators/collection_druid_validator.rb
+++ b/app/validators/collection_druid_validator.rb
@@ -8,16 +8,9 @@ class CollectionDruidValidator < ActiveModel::EachValidator
     # This prevents an invalid druid from causing find from failing with an OpenAPI error.
     return if record.errors[attribute].present?
 
-    cocina_obj = dor_services_client.object(value).find
+    cocina_obj = Dor::Services::Client.object(value).find
     record.errors.add attribute, 'not a collection' unless cocina_obj.collection?
   rescue Dor::Services::Client::NotFoundResponse
     record.errors.add attribute, 'does not exist'
-  end
-
-  private
-
-  def dor_services_client
-    @dor_services_client ||= Dor::Services::Client.configure(url: Settings.dor_services.url,
-                                                             token: Settings.dor_services.token)
   end
 end

--- a/config/initializers/dor_services_client.rb
+++ b/config/initializers/dor_services_client.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+# Configure dor-services-client to use the dor-services URL
+Dor::Services::Client.configure(url: Settings.dor_services.url,
+                                token: Settings.dor_services.token)

--- a/lib/tasks/audit.rake
+++ b/lib/tasks/audit.rake
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+desc 'Audit accessioned WARCs against WARCs available from WASAPI provider'
+task :audit, %i[collection_druid] => :environment do |_task, args|
+  collection = Collection.find_by(druid: args[:collection_druid])
+  puts "Auditing #{collection.title}. This might take a minute."
+  puts Audit::WarcAuditer.audit(collection_druid: collection.druid,
+                                wasapi_collection_id: collection.wasapi_collection_id,
+                                wasapi_account: collection.wasapi_account,
+                                wasapi_provider: collection.wasapi_provider)
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,6 +13,7 @@ require File.expand_path('../config/environment', __dir__)
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
 require 'capybara/rspec'
+require 'webmock/rspec'
 
 # Add additional requires below this line. Rails is not loaded until this point!
 
@@ -68,3 +69,5 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   require 'cocina/rspec'
 end
+
+WebMock.disable_net_connect!

--- a/spec/services/audit/sdr_warc_lister_spec.rb
+++ b/spec/services/audit/sdr_warc_lister_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Audit::SdrWarcLister do
+  let(:files) { described_class.new(collection_druid: 'druid:hw105qf0103').to_a }
+
+  let(:object_client) { instance_double(Dor::Services::Client::Object, members: members) }
+  let(:object_client1) { instance_double(Dor::Services::Client::Object, find: cocina1) }
+  let(:object_client2) { instance_double(Dor::Services::Client::Object, find: cocina2) }
+  let(:members) do
+    [
+      Dor::Services::Client::Members::Member.new(externalIdentifier: 'druid:cv062jz2211', type: 'item'),
+      Dor::Services::Client::Members::Member.new(externalIdentifier: 'druid:kx571tc4076', type: 'item')
+    ]
+  end
+  let(:cocina1) do
+    build(:dro, id: 'druid:cv062jz2211', type: Cocina::Models::ObjectType.webarchive_binary).new(
+      structural: {
+        contains: [{
+          type: 'https://cocina.sul.stanford.edu/models/resources/file',
+          externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/kx571tc4076-kx571tc4076_1',
+          label: '',
+          version: 1,
+          structural: {
+            contains: [{
+              type: 'https://cocina.sul.stanford.edu/models/file',
+              externalIdentifier: 'https://cocina.sul.stanford.edu/file/kx571tc4076-kx571tc4076_1/ARCHIVEIT-12189-ONE_TIME-JOB915353-SEED2014399-20190523220742664-00000-h3.warc.gz',
+              label: 'ARCHIVEIT-12189-ONE_TIME-JOB915353-SEED2014399-20190523220742664-00000-h3.warc.gz',
+              filename: 'ARCHIVEIT-12189-ONE_TIME-JOB915353-SEED2014399-20190523220742664-00000-h3.warc.gz',
+              size: 1_002_084_829,
+              version: 1,
+              hasMimeType: 'application/warc',
+              hasMessageDigests: [{
+                type: 'sha1',
+                digest: '7baed835ed1f3c6c08e831697baab9412b91c152'
+              }, {
+                type: 'md5',
+                digest: 'e3ef04d8a94e755fe350f7de24a854f1'
+              }],
+              access: {
+                view: 'dark',
+                download: 'none',
+                controlledDigitalLending: false
+              },
+              administrative: {
+                publish: false,
+                sdrPreserve: true,
+                shelve: false
+              }
+            }]
+          }
+        }, {
+          type: 'https://cocina.sul.stanford.edu/models/resources/file',
+          externalIdentifier: 'https://cocina.sul.stanford.edu/fileSet/kx571tc4076-kx571tc4076_2',
+          label: '',
+          version: 1,
+          structural: {
+            contains: [{
+              type: 'https://cocina.sul.stanford.edu/models/file',
+              externalIdentifier: 'https://cocina.sul.stanford.edu/file/kx571tc4076-kx571tc4076_2/ARCHIVEIT-12189-ONE_TIME-JOB915353-SEED2014399-20190523233238785-00001-h3.warc.gz',
+              label: 'ARCHIVEIT-12189-ONE_TIME-JOB915353-SEED2014399-20190523233238785-00001-h3.warc.gz',
+              filename: 'ARCHIVEIT-12189-ONE_TIME-JOB915353-SEED2014399-20190523233238785-00001-h3.warc.gz',
+              size: 1_008_717_262,
+              version: 1,
+              hasMimeType: 'application/warc',
+              hasMessageDigests: [{
+                type: 'sha1',
+                digest: '8938acbcfd24aab7333319469b018608bcebe76b'
+              }, {
+                type: 'md5',
+                digest: '6599bd32ebc09b6036cd63dfc886d517'
+              }],
+              access: {
+                view: 'dark',
+                download: 'none',
+                controlledDigitalLending: false
+              },
+              administrative: {
+                publish: false,
+                sdrPreserve: true,
+                shelve: false
+              }
+            }]
+          }
+        }],
+        hasMemberOrders: [],
+        isMemberOf: ['druid:hw105qf0103']
+      }
+    )
+  end
+  let(:cocina2) { build(:dro, id: 'druid:kx571tc4076', type: Cocina::Models::ObjectType.webarchive_seed) }
+
+  before do
+    allow(Dor::Services::Client).to receive(:object).and_return(object_client, object_client1, object_client2)
+    allow(cocina2).to receive(:structural)
+  end
+
+  it 'lists files' do
+    expect(files).to eq([
+                          'ARCHIVEIT-12189-ONE_TIME-JOB915353-SEED2014399-20190523220742664-00000-h3.warc.gz',
+                          'ARCHIVEIT-12189-ONE_TIME-JOB915353-SEED2014399-20190523233238785-00001-h3.warc.gz'
+                        ])
+    expect(Dor::Services::Client).to have_received(:object)
+      .with('druid:hw105qf0103').with('druid:cv062jz2211').with('druid:kx571tc4076')
+    expect(cocina2).not_to have_received(:structural)
+  end
+end

--- a/spec/services/audit/warc_auditer_spec.rb
+++ b/spec/services/audit/warc_auditer_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Audit::WarcAuditer do
+  let(:files) do
+    described_class.audit(collection_druid: 'druid:hw105qf0103', wasapi_collection_id: '12189', wasapi_account: 'ua')
+  end
+
+  before do
+    allow(Audit::WasapiWarcLister).to receive(:new).and_return(['FILE_1.warc.gz', 'FILE_2.warc.gz', 'FILE_3.warc.gz'])
+    allow(Audit::SdrWarcLister).to receive(:new).and_return(['FILE_2.warc.gz', 'FILE_3.warc.gz', 'FILE_4.warc.gz'])
+  end
+
+  it 'returns missing files' do
+    expect(files).to eq(['FILE_1.warc.gz'])
+    expect(Audit::WasapiWarcLister).to have_received(:new).with(wasapi_collection_id: '12189', wasapi_provider: 'ait',
+                                                                wasapi_account: 'ua')
+    expect(Audit::SdrWarcLister).to have_received(:new).with(collection_druid: 'druid:hw105qf0103')
+  end
+end

--- a/spec/services/audit/wasapi_warc_lister_spec.rb
+++ b/spec/services/audit/wasapi_warc_lister_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Audit::WasapiWarcLister do
+  let(:files) { described_class.new(wasapi_collection_id: '12189', wasapi_provider: 'ait', wasapi_account: 'ua').to_a }
+
+  context 'when success' do
+    let(:body) do
+      <<~JSON
+        {
+          "count": 2,
+          "next": null,
+          "previous": null,
+          "files": [{
+            "filename": "ARCHIVEIT-12189-ONE_TIME-JOB915353-SEED2014399-20190524001959215-00002-h3.warc.gz",
+            "filetype": "warc",
+            "checksums": {
+              "md5": "611182afc6b5986c93b99c826bdbf2cf",
+              "sha1": "74af193a5d6ec78f7431c0c8eab9bc3936495fda"
+            },
+            "account": 198,
+            "size": 243582220,
+            "collection": 12189,
+            "crawl": 915353,
+            "crawl-time": "2019-05-24T00:19:59.215000Z",
+            "crawl-start": "2019-05-23T22:07:38.802000Z",
+            "store-time": "2019-05-24T00:53:24.703627Z",
+            "locations": ["https://warcs.archive-it.org/webdatafile/ARCHIVEIT-12189-ONE_TIME-JOB915353-SEED2014399-20190524001959215-00002-h3.warc.gz", "https://archive.org/download/ARCHIVEIT-12189-ONE_TIME-JOB915353-SEED2014399-20190524-00000/ARCHIVEIT-12189-ONE_TIME-JOB915353-SEED2014399-20190524001959215-00002-h3.warc.gz"]
+          }, {
+            "filename": "ARCHIVEIT-12189-ONE_TIME-JOB915353-SEED2014399-20190523233238785-00001-h3.warc.gz",
+            "filetype": "warc",
+            "checksums": {
+              "md5": "6599bd32ebc09b6036cd63dfc886d517",
+              "sha1": "8938acbcfd24aab7333319469b018608bcebe76b"
+            },
+            "account": 198,
+            "size": 1008717262,
+            "collection": 12189,
+            "crawl": 915353,
+            "crawl-time": "2019-05-23T23:32:38.785000Z",
+            "crawl-start": "2019-05-23T22:07:38.802000Z",
+            "store-time": "2019-05-24T00:38:47.150419Z",
+            "locations": ["https://warcs.archive-it.org/webdatafile/ARCHIVEIT-12189-ONE_TIME-JOB915353-SEED2014399-20190523233238785-00001-h3.warc.gz", "https://archive.org/download/ARCHIVEIT-12189-ONE_TIME-JOB915353-SEED2014399-20190523-00000/ARCHIVEIT-12189-ONE_TIME-JOB915353-SEED2014399-20190523233238785-00001-h3.warc.gz"]
+          }],
+          "includes-extra": false,
+          "request-url": "https://archive-it.org/webdata?collection=12189"
+        }
+      JSON
+    end
+
+    before do
+      stub_request(:get, 'https://archive-it.org/webdata?collection=12189')
+        .with(
+          headers: {
+            'Authorization' => 'Basic dXNlcjpwYXNz',
+            'Content-Type' => 'application/json'
+          }
+        )
+        .to_return(status: 200, body: body, headers: {})
+    end
+
+    it 'returns files' do
+      expect(files).to eq(
+        [
+          'ARCHIVEIT-12189-ONE_TIME-JOB915353-SEED2014399-20190524001959215-00002-h3.warc.gz',
+          'ARCHIVEIT-12189-ONE_TIME-JOB915353-SEED2014399-20190523233238785-00001-h3.warc.gz'
+        ]
+      )
+    end
+  end
+
+  context 'when an error' do
+    before do
+      stub_request(:get, 'https://archive-it.org/webdata?collection=12189')
+        .with(
+          headers: {
+            'Authorization' => 'Basic dXNlcjpwYXNz',
+            'Content-Type' => 'application/json'
+          }
+        )
+        .to_return(status: 403, body: '', headers: {})
+    end
+
+    it 'raises' do
+      expect { files }.to raise_error('Getting https://archive-it.org/webdata?collection=12189 returned 403')
+    end
+  end
+end


### PR DESCRIPTION
closes #428

## Why was this change made? 🤔
Complete data.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning (and maybe even SWAP system?) works properly in [stage|qa] environment, in addition to specs. ⚡

Stage, unit
