### PR TITLE
Temporarily disabling fetching collections

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -11,6 +11,7 @@
 #
 # Learn more: http://github.com/javan/whenever
 
-every 1.day do
-  rake 'fetch_collections'
-end
+# Temporarily disabling this during pywb rollout. See https://github.com/sul-dlss/was-registrar-app/issues/482
+# every 1.day do
+#  rake 'fetch_collections'
+# end


### PR DESCRIPTION
refs #482

## Why was this change made? 🤔
To avoid having to reindex.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning (and maybe even SWAP system?) works properly in [stage|qa] environment, in addition to specs. ⚡


