### PR TITLE
Validate that source id is unique for one-time registration.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem 'view_component', '~> 2.0'
 gem 'auto_strip_attributes'
 # For configuration
 gem 'config', '~> 2.0'
-gem 'dor-services-client', '~> 12.0'
+gem 'dor-services-client', '~> 12.5'
 gem 'dor-workflow-client', '~> 4.0'
 gem 'honeybadger'
 gem 'okcomputer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,7 +149,7 @@ GEM
       capistrano-one_time_key
       capistrano-shared_configs
     docile (1.4.0)
-    dor-services-client (12.4.0)
+    dor-services-client (12.5.0)
       activesupport (>= 4.2, < 8)
       cocina-models (~> 0.82.0)
       deprecation
@@ -444,7 +444,7 @@ DEPENDENCIES
   config (~> 2.0)
   cssbundling-rails
   dlss-capistrano
-  dor-services-client (~> 12.0)
+  dor-services-client (~> 12.5)
   dor-workflow-client (~> 4.0)
   factory_bot_rails
   honeybadger

--- a/app/models/registration_job.rb
+++ b/app/models/registration_job.rb
@@ -10,7 +10,7 @@ class RegistrationJob < ApplicationRecord
   validates :status, inclusion: { in: %w[waiting running success failure] }
   validates :collection, format: { with: /\Adruid:[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}\z/,
                                    message: 'must be a valid druid beginning with druid:' }, collection_druid: true
-  validates :source_id, format: { with: /\A.+:.+\z/, message: 'must be namespace:identifier' }
+  validates :source_id, format: { with: /\A.+:.+\z/, message: 'must be namespace:identifier' }, unique_source_id: true
   validates :job_directory, job_directory: true
 
   def crawl_directory

--- a/app/validators/unique_source_id_validator.rb
+++ b/app/validators/unique_source_id_validator.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Validates that source Id is unique.
+class UniqueSourceIdValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    return unless Settings.validate_source_id
+    # If there are already errors, the return.
+    # This prevents an invalid source id from causing find from failing with an OpenAPI error.
+    return if record.errors[attribute].present?
+
+    Dor::Services::Client.objects.find(source_id: value)
+    record.errors.add attribute, 'already exists'
+  rescue Dor::Services::Client::NotFoundResponse
+    # Does not exist, so no error.
+  end
+end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -14,3 +14,4 @@ argo_view_url: https://argo.stanford.edu/view/%s
 
 validate_collection_druid: true
 validate_job_directory: true
+validate_source_id: true

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -21,3 +21,4 @@ wasapi_providers:
 crawl_directory: tmp/jobs
 wasapi_downloader_bin: wasapi-downloader/bin/wasapi-downloader
 validate_collection_druid: false
+validate_source_id: false

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -22,3 +22,4 @@ crawl_directory: spec/fixtures/jobs
 wasapi_downloader_bin: wasapi-downloader/bin/wasapi-downloader
 validate_collection_druid: false
 validate_job_directory: false
+validate_source_id: false


### PR DESCRIPTION
closes #471

## Why was this change made? 🤔
Prevent user error.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning (and maybe even SWAP system?) works properly in [stage|qa] environment, in addition to specs. ⚡

Unit, QA

