### PR TITLE
Limit validation when status is not waiting for RegistrationJob.

### DIFF
--- a/app/jobs/registering.rb
+++ b/app/jobs/registering.rb
@@ -15,15 +15,15 @@ module Registering
   end
 
   def success_status(obj, druid: nil)
-    obj.update(crawl_item_druid: druid, status: 'success', failure_reason: nil)
+    obj.update!(crawl_item_druid: druid, status: 'success', failure_reason: nil)
   end
 
   def running_status(obj)
-    obj.update(status: 'running', failure_reason: nil)
+    obj.update!(status: 'running', failure_reason: nil)
   end
 
   def failure_status(obj, exception)
-    obj&.update(failure_reason: exception.to_s, status: 'failure')
+    obj&.update!(failure_reason: exception.to_s, status: 'failure')
   end
 
   def register(request_params)

--- a/app/models/registration_job.rb
+++ b/app/models/registration_job.rb
@@ -9,9 +9,14 @@ class RegistrationJob < ApplicationRecord
   validates :admin_policy, inclusion: { in: %w[druid:wr005wn5739 druid:yf700yh0557] }
   validates :status, inclusion: { in: %w[waiting running success failure] }
   validates :collection, format: { with: /\Adruid:[b-df-hjkmnp-tv-z]{2}[0-9]{3}[b-df-hjkmnp-tv-z]{2}[0-9]{4}\z/,
-                                   message: 'must be a valid druid beginning with druid:' }, collection_druid: true
-  validates :source_id, format: { with: /\A.+:.+\z/, message: 'must be namespace:identifier' }, unique_source_id: true
-  validates :job_directory, job_directory: true
+                                   message: 'must be a valid druid beginning with druid:' }
+  validates :source_id, format: { with: /\A.+:.+\z/, message: 'must be namespace:identifier' }
+
+  with_options if: proc { |registration_job| registration_job.status == 'waiting' } do
+    validates :collection, collection_druid: true
+    validates :source_id, unique_source_id: true
+    validates :job_directory, job_directory: true
+  end
 
   def crawl_directory
     File.join(Settings.crawl_directory, job_directory)

--- a/spec/models/registration_job_spec.rb
+++ b/spec/models/registration_job_spec.rb
@@ -28,9 +28,15 @@ RSpec.describe RegistrationJob, type: :model do
         expect(registration_job.valid?).to be(false)
       end
 
-      it 'validates job_directory when missing' do
+      it 'validates job_directory when missing and status is waiting' do
         registration_job.job_directory = 'foo'
         expect(registration_job.valid?).to be(false)
+      end
+
+      it 'validates job_directory when missing and status is not waiting' do
+        registration_job.status = 'running'
+        registration_job.job_directory = 'foo'
+        expect(registration_job.valid?).to be(true)
       end
 
       it 'validates collection druid must begin with druid' do
@@ -57,7 +63,7 @@ RSpec.describe RegistrationJob, type: :model do
         allow(Dor::Services::Client).to receive(:objects).and_return(objects_client)
       end
 
-      context 'when found' do
+      context 'when found and status is waiting' do
         before do
           allow(objects_client).to receive(:find).and_return(instance_double(Cocina::Models::DRO))
         end
@@ -68,12 +74,59 @@ RSpec.describe RegistrationJob, type: :model do
         end
       end
 
+      context 'when status is not waiting' do
+        it 'does not validate' do
+          registration_job.status = 'running'
+          expect(registration_job.valid?).to be(true)
+        end
+      end
+
       context 'when not found' do
         before do
           allow(objects_client).to receive(:find).and_raise(Dor::Services::Client::NotFoundResponse)
         end
 
         it 'is valid' do
+          expect(registration_job.valid?).to be(true)
+        end
+      end
+    end
+
+    context 'when validating collection druid' do
+      let(:object_client) { instance_double(Dor::Services::Client::Object) }
+
+      before do
+        allow(Settings).to receive(:validate_collection_druid).and_return(true)
+        allow(Dor::Services::Client).to receive(:object).and_return(object_client)
+      end
+
+      context 'when druid found and a collection' do
+        let(:cocina_obj) { instance_double(Cocina::Models::Collection, collection?: true) }
+
+        before do
+          allow(object_client).to receive(:find).and_return(cocina_obj)
+        end
+
+        it 'is not valid' do
+          expect(registration_job.valid?).to be(true)
+          expect(Dor::Services::Client).to have_received(:object).with('druid:bf172jb9970')
+        end
+      end
+
+      context 'when not found' do
+        before do
+          allow(object_client).to receive(:find).and_raise(Dor::Services::Client::NotFoundResponse)
+        end
+
+        it 'is valid' do
+          expect(registration_job.valid?).to be(false)
+          expect(registration_job.errors[:collection]).to eq(['does not exist'])
+        end
+      end
+
+      context 'when status is not waiting' do
+        it 'does not validate' do
+          registration_job.status = 'running'
           expect(registration_job.valid?).to be(true)
         end
       end


### PR DESCRIPTION
## Why was this change made? 🤔
Some validation only applies for a new registration job; for other registration jobs the validation prevents saving.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning (and maybe even SWAP system?) works properly in [stage|qa] environment, in addition to specs. ⚡

stage
