### PR TITLE
Update docker compose to use bin/dev for web service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.0-alpine
+FROM ruby:3.1-alpine
 
 RUN apk add --update --no-cache \
   build-base \
@@ -12,8 +12,10 @@ WORKDIR /app
 COPY Gemfile Gemfile.lock /app/
 RUN gem install bundler && bundle install
 
+RUN gem install foreman
+
 COPY package.json yarn.lock /app/
 RUN yarn install --check-files
 COPY . .
 
-CMD puma -C config/puma.rb
+CMD ["docker/invoke.sh"]

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,3 @@
-web: bin/rails server -p 3000
+web: bin/rails server -b 0.0.0.0 -p 3000
 css: yarn build:css --watch
 js: yarn build --watch

--- a/README.md
+++ b/README.md
@@ -79,6 +79,17 @@ bin/dev
 ```
 This starts css/js bundling and the development server
 
+Alernatively, you can start use docker compose:
+```
+docker compose up -d
+```
+
+if you want to run the web container in intractive mode, stop it first and then run it so it will show interactive live output:
+```
+docker compose stop web
+docker compose run --service-ports web
+```
+
 ## Background processing
 Background processing is performed by [Sidekiq](https://github.com/mperham/sidekiq).
 

--- a/bin/dev
+++ b/bin/dev
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 foreman start -f Procfile.dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,11 +9,15 @@ services:
       - POSTGRES_HOST=db
       - REDIS_URL=redis://redis:6379/1
       - RAILS_ENV=development
+      - NODE_ENV=development
     volumes:
       - ./:/app
+      - node_modules:/app/node_modules
     depends_on:
       - db
       - redis
+    # To allow yarn --watch from Procfile.dev to continue after stdin is closed
+    tty: true
   sidekiq:
     build: .
     command: sidekiq
@@ -39,3 +43,4 @@ services:
       - 6379:6379
 volumes:
   postgres-data:
+  node_modules:

--- a/docker/invoke.sh
+++ b/docker/invoke.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+if [ -f tmp/pids/server.pid ]; then
+  rm tmp/pids/server.pid
+fi
+
+exec bin/dev


### PR DESCRIPTION
## Why was this change made? 🤔
Closes #470 

This copies much of the work done in Argo to make docker-compose utilize bin/dev for local execution.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning (and maybe even SWAP system?) works properly in [stage|qa] environment, in addition to specs. ⚡


