### PR TITLE
Adds rake task for remediation.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,10 @@ Metrics/MethodLength:
   Exclude:
     - db/migrate/*
 
+Metrics/ParameterLists:
+  Exclude:
+    - app/services/audit/warc_remediator.rb
+
 RSpec/LetSetup:
   Exclude:
     - spec/services/fetch_job_retrier_spec.rb

--- a/README.md
+++ b/README.md
@@ -113,4 +113,11 @@ use the audit rake task: `bin/rake audit['<collection druid>']`
 
 For example: `RAILS_ENV=production bin/rake audit['druid:hw105qf0103']`
 
-This will return a list of WARC filenames that are available but have not been accessioned.
+This will return a list of WARC filenames that are available but have not been accessioned. This will respect embargoes
+and exclude WARCs from the current month.
+
+## Remediating
+To fetch and initiate a one-time registration for missing WARCs (based on the auditing procedure described above),
+use the remediate rake task: `bin/rake remediate['<collection druid>']`
+
+For example: `RAILS_ENV=production bin/rake remediate['druid:hw105qf0103']`

--- a/app/services/audit/warc_auditer.rb
+++ b/app/services/audit/warc_auditer.rb
@@ -4,16 +4,17 @@ module Audit
   # Audits accessioned WARCs against WARCs available from a WASAPI provider.
   class WarcAuditer
     # @return [Array<String>] filenames that are available from WASAPI provider but have not been accessioned
-    def self.audit(collection_druid:, wasapi_collection_id:, wasapi_account:, wasapi_provider: 'ait')
+    def self.audit(collection_druid:, wasapi_collection_id:, wasapi_account:, wasapi_provider: 'ait', embargo_months: 0)
       new(collection_druid: collection_druid, wasapi_collection_id: wasapi_collection_id,
-          wasapi_account: wasapi_account, wasapi_provider: wasapi_provider).audit
+          wasapi_account: wasapi_account, wasapi_provider: wasapi_provider, embargo_months: embargo_months).audit
     end
 
-    def initialize(collection_druid:, wasapi_collection_id:, wasapi_account:, wasapi_provider:)
+    def initialize(collection_druid:, wasapi_collection_id:, wasapi_account:, wasapi_provider:, embargo_months:)
       @collection_druid = collection_druid
       @wasapi_collection_id = wasapi_collection_id
       @wasapi_account = wasapi_account
       @wasapi_provider = wasapi_provider
+      @embargo_months = embargo_months
     end
 
     def audit
@@ -22,11 +23,11 @@ module Audit
 
     private
 
-    attr_reader :collection_druid, :wasapi_collection_id, :wasapi_account, :wasapi_provider
+    attr_reader :collection_druid, :wasapi_collection_id, :wasapi_account, :wasapi_provider, :embargo_months
 
     def wasapi_warc_filenames
       WasapiWarcLister.new(wasapi_collection_id: wasapi_collection_id, wasapi_provider: wasapi_provider,
-                           wasapi_account: wasapi_account).to_a
+                           wasapi_account: wasapi_account, embargo_months: embargo_months).to_a
     end
 
     def sdr_warc_filenames

--- a/app/services/audit/warc_remediator.rb
+++ b/app/services/audit/warc_remediator.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+module Audit
+  # Retrieves WARC files from a WASAPI provider and initiates one-time registration.
+  class WarcRemediator
+    # @return [String] job directory
+    def self.remediate(collection_druid:, wasapi_collection_id:, wasapi_account:, filenames:, source_id: nil,
+                       admin_policy_druid: 'druid:wr005wn5739', wasapi_provider: 'ait')
+      new(collection_druid: collection_druid, source_id: source_id, admin_policy_druid: admin_policy_druid,
+          wasapi_collection_id: wasapi_collection_id, wasapi_account: wasapi_account, wasapi_provider: wasapi_provider,
+          filenames: filenames).remediate
+    end
+
+    def initialize(collection_druid:, admin_policy_druid:, wasapi_collection_id:, wasapi_account:, wasapi_provider:,
+                   filenames:, source_id: nil)
+      @collection_druid = collection_druid
+      @admin_policy_druid = admin_policy_druid
+      @wasapi_collection_id = wasapi_collection_id
+      @wasapi_account = wasapi_account
+      @wasapi_provider = wasapi_provider
+      @filenames = filenames
+      @job_id = "patch-missing-#{Time.zone.today.strftime('%Y_%m_%d')}"
+      @source_id = source_id || "sul:#{wasapi_provider.upcase}-#{wasapi_collection_id}-#{@job_id}"
+    end
+
+    def remediate
+      fetch
+      register
+
+      job_directory
+    end
+
+    private
+
+    attr_reader :collection_druid, :source_id, :admin_policy_druid,
+                :wasapi_collection_id, :wasapi_account, :wasapi_provider, :filenames, :job_id
+
+    def job_directory
+      @job_directory ||= File.join("#{wasapi_provider.upcase}_#{wasapi_collection_id}",
+                                   job_id)
+    end
+
+    def crawl_directory
+      @crawl_directory ||= File.join(Settings.crawl_directory, job_directory)
+    end
+
+    def fetch
+      FileUtils.mkdir_p(crawl_directory)
+      filenames.each { |filename| fetch_warc(filename) }
+    end
+
+    def fetch_warc(filename)
+      _, stderr, status = Open3.capture3(Settings.wasapi_downloader_bin, *downloader_args(filename))
+      return if status.success?
+
+      raise "Fetching WARCs failed: #{stderr}"
+    end
+
+    def downloader_args(filename)
+      ['--filename', filename,
+       '--baseurl', wasapi_provider_config.baseurl,
+       '--authurl', wasapi_provider_config.authurl,
+       '--username', wasapi_account_config.username,
+       '--password', wasapi_account_config.password,
+       '--outputBaseDir', "#{crawl_directory}/",
+       '--resume']
+    end
+
+    def wasapi_provider_config
+      @wasapi_provider_config ||= Settings.wasapi_providers[wasapi_provider]
+    end
+
+    def wasapi_account_config
+      @wasapi_account_config ||= wasapi_provider_config.accounts[wasapi_account]
+    end
+
+    def register
+      registration_job = RegistrationJob.create!(job_directory: job_directory, collection: collection_druid,
+                                                 admin_policy: admin_policy_druid, source_id: source_id)
+      RegisterJob.perform_later(registration_job)
+    end
+  end
+end

--- a/spec/services/audit/warc_auditer_spec.rb
+++ b/spec/services/audit/warc_auditer_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 
 RSpec.describe Audit::WarcAuditer do
   let(:files) do
-    described_class.audit(collection_druid: 'druid:hw105qf0103', wasapi_collection_id: '12189', wasapi_account: 'ua')
+    described_class.audit(collection_druid: 'druid:hw105qf0103', wasapi_collection_id: '12189', wasapi_account: 'ua',
+                          embargo_months: 3)
   end
 
   before do
@@ -15,7 +16,7 @@ RSpec.describe Audit::WarcAuditer do
   it 'returns missing files' do
     expect(files).to eq(['FILE_1.warc.gz'])
     expect(Audit::WasapiWarcLister).to have_received(:new).with(wasapi_collection_id: '12189', wasapi_provider: 'ait',
-                                                                wasapi_account: 'ua')
+                                                                wasapi_account: 'ua', embargo_months: 3)
     expect(Audit::SdrWarcLister).to have_received(:new).with(collection_druid: 'druid:hw105qf0103')
   end
 end

--- a/spec/services/audit/warc_remediator_spec.rb
+++ b/spec/services/audit/warc_remediator_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Audit::WarcRemediator do
+  let(:job_directory) do
+    described_class.remediate(collection_druid: 'druid:gq319xk9269', wasapi_collection_id: '12189',
+                              wasapi_account: 'ua', filenames: ['AIT-12189-1.warc.gz'])
+  end
+
+  before do
+    allow(Time.zone).to receive(:today).and_return(Time.zone.parse('2021-01-01'))
+    allow(FileUtils).to receive(:mkdir_p)
+  end
+
+  context 'when fetch succeeds' do
+    let(:status) { instance_double(Process::Status, success?: true) }
+    let(:registration_job) { instance_double(RegistrationJob) }
+
+    before do
+      allow(Open3).to receive(:capture3).and_return([nil, nil, status])
+      allow(RegistrationJob).to receive(:create!).and_return(registration_job)
+      allow(RegisterJob).to receive(:perform_later)
+    end
+
+    it 'fetches and registers' do
+      expect(job_directory).to eq('AIT_12189/patch-missing-2021_01_01')
+      expect(FileUtils).to have_received(:mkdir_p).with('spec/fixtures/jobs/AIT_12189/patch-missing-2021_01_01')
+      expect(Open3).to have_received(:capture3).with('wasapi-downloader/bin/wasapi-downloader', '--filename',
+                                                     'AIT-12189-1.warc.gz', '--baseurl', 'https://archive-it.org/',
+                                                     '--authurl', 'https://archive-it.org/login', '--username', 'user',
+                                                     '--password', 'pass',
+                                                     '--outputBaseDir',
+                                                     'spec/fixtures/jobs/AIT_12189/patch-missing-2021_01_01/',
+                                                     '--resume')
+      expect(RegistrationJob).to have_received(:create!).with(admin_policy: 'druid:wr005wn5739',
+                                                              collection: 'druid:gq319xk9269',
+                                                              job_directory: 'AIT_12189/patch-missing-2021_01_01',
+                                                              source_id: 'sul:AIT-12189-patch-missing-2021_01_01')
+      expect(RegisterJob).to have_received(:perform_later).with(registration_job)
+    end
+  end
+
+  context 'when fetch fails' do
+    let(:status) { instance_double(Process::Status, success?: false) }
+
+    before do
+      allow(Open3).to receive(:capture3).and_return([nil, 'Not found', status])
+    end
+
+    it 'raises an error' do
+      expect { job_directory }.to raise_error(RuntimeError, 'Fetching WARCs failed: Not found')
+    end
+  end
+end


### PR DESCRIPTION
refs #486

## Why was this change made? 🤔
Support remediation for missing WARCs.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning (and maybe even SWAP system?) works properly in [stage|qa] environment, in addition to specs. ⚡

Unit, QA
