### PR TITLE
Sets a minimum embargo of 1 month.

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -17,6 +17,7 @@ class Collection < ApplicationRecord
   validates_uniqueness_of :wasapi_collection_id,
                           scope: %i[wasapi_provider wasapi_account],
                           message: 'already have a collection configured for this WASAPI collection'
+  validates :embargo_months, comparison: { greater_than: 0 }
 
   def wasapi_provider_account
     wasapi_provider && wasapi_account ? "#{wasapi_provider}:#{wasapi_account}" : nil

--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -8,7 +8,7 @@
                   order: [:month, :year] %>
       <%= form.input :wasapi_provider_account, label: 'WASAPI provider / account', collection: @wasapi_provider_accounts %>
       <%= form.input :wasapi_collection_id, label: 'WASAPI collection id' %>
-      <%= form.input :embargo_months %>
+      <%= form.input :embargo_months, input_html: { min: '1' } %>
       <%= form.input :admin_policy, collection: [
           ['Web Archive Crawl Object Public APO', 'druid:wr005wn5739'],
           ['Web Archive Crawl Object Dark APO', 'druid:yf700yh0557']

--- a/db/migrate/20220720185025_set_embargo.rb
+++ b/db/migrate/20220720185025_set_embargo.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class SetEmbargo < ActiveRecord::Migration[7.0]
+  def change
+    Collection.connection.execute('UPDATE collections SET embargo_months = 1 WHERE embargo_months = 0')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_06_08_130715) do
+ActiveRecord::Schema[7.0].define(version: 2022_07_20_185025) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -33,8 +33,13 @@ RSpec.describe Collection, type: :model do
       expect(collection.valid?).to be(false)
     end
 
-    it 'validates embargo_months' do
+    it 'validates embargo_months is present' do
       collection.embargo_months = nil
+      expect(collection.valid?).to be(false)
+    end
+
+    it 'validates embargo_months is greater than 0' do
+      collection.embargo_months = 0
       expect(collection.valid?).to be(false)
     end
 

--- a/spec/services/fetch_job_creator_spec.rb
+++ b/spec/services/fetch_job_creator_spec.rb
@@ -41,9 +41,9 @@ RSpec.describe FetchJobCreator do
     end
   end
 
-  context 'when there is no embargo' do
+  context 'when there is minimum embargo' do
     let(:collection) do
-      create(:ar_collection, embargo_months: 0, fetch_start_month: '2018-10-01')
+      create(:ar_collection, embargo_months: 1, fetch_start_month: '2018-10-01')
     end
 
     context 'with a collection that has fetch months' do
@@ -54,10 +54,10 @@ RSpec.describe FetchJobCreator do
       it 'creates fetch_months' do
         run
         expect(collection.fetch_months.map { |m| [m.year, m.month] }).to eq [
-          [2018, 11], [2018, 12], [2019, 1], [2019, 2], [2019, 3], [2019, 4], [2019, 5], [2019, 6], [2019, 7]
+          [2018, 11], [2018, 12], [2019, 1], [2019, 2], [2019, 3], [2019, 4], [2019, 5], [2019, 6]
         ]
         # 2018-11 already exists, so won't be performed here.
-        expect(FetchJob).to have_received(:perform_later).exactly(8).times
+        expect(FetchJob).to have_received(:perform_later).exactly(7).times
       end
     end
 
@@ -65,10 +65,9 @@ RSpec.describe FetchJobCreator do
       it 'creates fetch_months' do
         run
         expect(collection.fetch_months.map { |m| [m.year, m.month] }).to eq [
-          [2018, 10], [2018, 11], [2018, 12], [2019, 1], [2019, 2], [2019, 3], [2019, 4], [2019, 5], [2019, 6],
-          [2019, 7]
+          [2018, 10], [2018, 11], [2018, 12], [2019, 1], [2019, 2], [2019, 3], [2019, 4], [2019, 5], [2019, 6]
         ]
-        expect(FetchJob).to have_received(:perform_later).exactly(10).times
+        expect(FetchJob).to have_received(:perform_later).exactly(9).times
       end
     end
   end


### PR DESCRIPTION
closes #500

## Why was this change made? 🤔
This avoids a race condition with Archive-It making WARC files available.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning (and maybe even SWAP system?) works properly in [stage|qa] environment, in addition to specs. ⚡

Unit, local
