### PR TITLE
Adds rake task for auditing and remediating non-WRA collections.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/825ca3f3c2fe04d3319c/test_coverage)](https://codeclimate.com/github/sul-dlss/was-registrar-app/test_coverage)
 [![Maintainability](https://api.codeclimate.com/v1/badges/825ca3f3c2fe04d3319c/maintainability)](https://codeclimate.com/github/sul-dlss/was-registrar-app/maintainability)
 
-The WAS Registrar App is a Rails application that:
+The WAS Registrar App (WRA) is a Rails application that:
 * Allows a web archivist to update configuration and schedule web archive collections to be fetched.
 * Allows a web archivist to monitor fetch workflow outcomes.
 * Initiates web archive fetch workflows according to schedule.
@@ -109,15 +109,27 @@ To deploy to [production](https://was-registrar-app.stanford.edu): `bundle exec 
 
 ## Auditing
 To audit the WARCs that have been accessioned in SDR against the WARCs available from a WASAPI provider,
-use the audit rake task: `bin/rake audit['<collection druid>']`
+use an audit rake task: 
+* For a collection that is configured in WRA: `bin/rake audit_collection['<collection druid>']`
+* For a collection that is not configured in WRA: `bin/rake audit['<collection_druid>','<wasapi_collection_id>','<wasapi_account>','<embargo_months>']`
 
-For example: `RAILS_ENV=production bin/rake audit['druid:hw105qf0103']`
+For example: 
+```
+RAILS_ENV=production bin/rake audit_collection['druid:hw105qf0103']`
+RAILS_ENV=production bin/rake audit['druid:gq319xk9269','14373','shl','1']
+```
 
 This will return a list of WARC filenames that are available but have not been accessioned. This will respect embargoes
 and exclude WARCs from the current month.
 
 ## Remediating
 To fetch and initiate a one-time registration for missing WARCs (based on the auditing procedure described above),
-use the remediate rake task: `bin/rake remediate['<collection druid>']`
+use a remediate rake task:
+* For a collection that is configured in WRA: `bin/rake remediate_collection['<collection druid>']`
+* For a collection that is not configured in WRA: `bin/rake remediate['<collection_druid>','<wasapi_collection_id>','<wasapi_account>','<embargo_months>']`
 
-For example: `RAILS_ENV=production bin/rake remediate['druid:hw105qf0103']`
+For example: 
+```
+RAILS_ENV=production bin/rake remediate_collection['druid:hw105qf0103']`
+RAILS_ENV=production bin/rake remediate['druid:gq319xk9269','14373','shl','1']
+```

--- a/app/services/audit/warc_auditer.rb
+++ b/app/services/audit/warc_auditer.rb
@@ -9,6 +9,15 @@ module Audit
           wasapi_account: wasapi_account, wasapi_provider: wasapi_provider, embargo_months: embargo_months).audit
     end
 
+    # @return [Array<String>] filenames that are available from WASAPI provider but have not been accessioned
+    def self.audit_collection(collection:)
+      audit(collection_druid: collection.druid,
+            wasapi_collection_id: collection.wasapi_collection_id,
+            wasapi_account: collection.wasapi_account,
+            wasapi_provider: collection.wasapi_provider,
+            embargo_months: collection.embargo_months)
+    end
+
     def initialize(collection_druid:, wasapi_collection_id:, wasapi_account:, wasapi_provider:, embargo_months:)
       @collection_druid = collection_druid
       @wasapi_collection_id = wasapi_collection_id

--- a/app/services/audit/warc_remediator.rb
+++ b/app/services/audit/warc_remediator.rb
@@ -13,6 +13,15 @@ module Audit
           filenames: filenames).remediate
     end
 
+    # @return [String] job directory
+    def self.remediate_collection(collection:, filenames:)
+      remediate(collection_druid: collection.druid,
+                wasapi_collection_id: collection.wasapi_collection_id,
+                wasapi_account: collection.wasapi_account,
+                wasapi_provider: collection.wasapi_provider,
+                filenames: filenames)
+    end
+
     def initialize(collection_druid:, admin_policy_druid:, wasapi_collection_id:, wasapi_account:, wasapi_provider:,
                    filenames:, source_id: nil)
       @collection_druid = collection_druid

--- a/spec/services/audit/warc_auditer_spec.rb
+++ b/spec/services/audit/warc_auditer_spec.rb
@@ -3,20 +3,50 @@
 require 'rails_helper'
 
 RSpec.describe Audit::WarcAuditer do
-  let(:files) do
-    described_class.audit(collection_druid: 'druid:hw105qf0103', wasapi_collection_id: '12189', wasapi_account: 'ua',
-                          embargo_months: 3)
+  context 'with params' do
+    let(:files) do
+      described_class.audit(collection_druid: 'druid:hw105qf0103', wasapi_collection_id: '12189', wasapi_account: 'ua',
+                            embargo_months: 3)
+    end
+
+    before do
+      allow(Audit::WasapiWarcLister).to receive(:new).and_return(['FILE_1.warc.gz', 'FILE_2.warc.gz', 'FILE_3.warc.gz'])
+      allow(Audit::SdrWarcLister).to receive(:new).and_return(['FILE_2.warc.gz', 'FILE_3.warc.gz', 'FILE_4.warc.gz'])
+    end
+
+    it 'returns missing files' do
+      expect(files).to eq(['FILE_1.warc.gz'])
+      expect(Audit::WasapiWarcLister).to have_received(:new).with(wasapi_collection_id: '12189', wasapi_provider: 'ait',
+                                                                  wasapi_account: 'ua', embargo_months: 3)
+      expect(Audit::SdrWarcLister).to have_received(:new).with(collection_druid: 'druid:hw105qf0103')
+    end
   end
 
-  before do
-    allow(Audit::WasapiWarcLister).to receive(:new).and_return(['FILE_1.warc.gz', 'FILE_2.warc.gz', 'FILE_3.warc.gz'])
-    allow(Audit::SdrWarcLister).to receive(:new).and_return(['FILE_2.warc.gz', 'FILE_3.warc.gz', 'FILE_4.warc.gz'])
-  end
+  context 'with a collection' do
+    let(:files) do
+      described_class.audit_collection(collection: collection)
+    end
 
-  it 'returns missing files' do
-    expect(files).to eq(['FILE_1.warc.gz'])
-    expect(Audit::WasapiWarcLister).to have_received(:new).with(wasapi_collection_id: '12189', wasapi_provider: 'ait',
-                                                                wasapi_account: 'ua', embargo_months: 3)
-    expect(Audit::SdrWarcLister).to have_received(:new).with(collection_druid: 'druid:hw105qf0103')
+    let(:collection) do
+      Collection.new(druid: 'druid:hw105qf0103', wasapi_collection_id: '12189', wasapi_account: 'ua',
+                     wasapi_provider: 'ait', embargo_months: 3)
+    end
+
+    let(:auditer) { instance_double(described_class, audit: filenames) }
+
+    let(:filenames) { ['FILE_1.warc.gz', 'FILE_2.warc.gz', 'FILE_3.warc.gz'] }
+
+    before do
+      allow(described_class).to receive(:new).and_return(auditer)
+    end
+
+    it 'invokes audit' do
+      expect(files).to eq(filenames)
+      expect(described_class).to have_received(:new).with(collection_druid: 'druid:hw105qf0103',
+                                                          wasapi_collection_id: '12189',
+                                                          wasapi_account: 'ua',
+                                                          wasapi_provider: 'ait',
+                                                          embargo_months: 3)
+    end
   end
 end

--- a/spec/services/audit/warc_remediator_spec.rb
+++ b/spec/services/audit/warc_remediator_spec.rb
@@ -3,53 +3,86 @@
 require 'rails_helper'
 
 RSpec.describe Audit::WarcRemediator do
-  let(:job_directory) do
-    described_class.remediate(collection_druid: 'druid:gq319xk9269', wasapi_collection_id: '12189',
-                              wasapi_account: 'ua', filenames: ['AIT-12189-1.warc.gz'])
-  end
-
-  before do
-    allow(Time.zone).to receive(:today).and_return(Time.zone.parse('2021-01-01'))
-    allow(FileUtils).to receive(:mkdir_p)
-  end
-
-  context 'when fetch succeeds' do
-    let(:status) { instance_double(Process::Status, success?: true) }
-    let(:registration_job) { instance_double(RegistrationJob) }
-
-    before do
-      allow(Open3).to receive(:capture3).and_return([nil, nil, status])
-      allow(RegistrationJob).to receive(:create!).and_return(registration_job)
-      allow(RegisterJob).to receive(:perform_later)
+  context 'with params' do
+    let(:job_directory) do
+      described_class.remediate(collection_druid: 'druid:gq319xk9269', wasapi_collection_id: '12189',
+                                wasapi_account: 'ua', filenames: ['AIT-12189-1.warc.gz'])
     end
 
-    it 'fetches and registers' do
+    before do
+      allow(Time.zone).to receive(:today).and_return(Time.zone.parse('2021-01-01'))
+      allow(FileUtils).to receive(:mkdir_p)
+    end
+
+    context 'when fetch succeeds' do
+      let(:status) { instance_double(Process::Status, success?: true) }
+      let(:registration_job) { instance_double(RegistrationJob) }
+
+      before do
+        allow(Open3).to receive(:capture3).and_return([nil, nil, status])
+        allow(RegistrationJob).to receive(:create!).and_return(registration_job)
+        allow(RegisterJob).to receive(:perform_later)
+      end
+
+      it 'fetches and registers' do
+        expect(job_directory).to eq('AIT_12189/patch-missing-2021_01_01')
+        expect(FileUtils).to have_received(:mkdir_p).with('spec/fixtures/jobs/AIT_12189/patch-missing-2021_01_01')
+        expect(Open3).to have_received(:capture3).with('wasapi-downloader/bin/wasapi-downloader', '--filename',
+                                                       'AIT-12189-1.warc.gz', '--baseurl', 'https://archive-it.org/',
+                                                       '--authurl', 'https://archive-it.org/login',
+                                                       '--username', 'user',
+                                                       '--password', 'pass',
+                                                       '--outputBaseDir',
+                                                       'spec/fixtures/jobs/AIT_12189/patch-missing-2021_01_01/',
+                                                       '--resume')
+        expect(RegistrationJob).to have_received(:create!).with(admin_policy: 'druid:wr005wn5739',
+                                                                collection: 'druid:gq319xk9269',
+                                                                job_directory: 'AIT_12189/patch-missing-2021_01_01',
+                                                                source_id: 'sul:AIT-12189-patch-missing-2021_01_01')
+        expect(RegisterJob).to have_received(:perform_later).with(registration_job)
+      end
+    end
+
+    context 'when fetch fails' do
+      let(:status) { instance_double(Process::Status, success?: false) }
+
+      before do
+        allow(Open3).to receive(:capture3).and_return([nil, 'Not found', status])
+      end
+
+      it 'raises an error' do
+        expect { job_directory }.to raise_error(RuntimeError, 'Fetching WARCs failed: Not found')
+      end
+    end
+  end
+
+  context 'with a collection' do
+    let(:job_directory) do
+      described_class.remediate_collection(collection: collection, filenames: filenames)
+    end
+
+    let(:collection) do
+      Collection.new(druid: 'druid:hw105qf0103', wasapi_collection_id: '12189', wasapi_account: 'ua',
+                     wasapi_provider: 'ait', embargo_months: 3)
+    end
+
+    let(:remediator) { instance_double(described_class, remediate: 'AIT_12189/patch-missing-2021_01_01') }
+
+    let(:filenames) { ['FILE_1.warc.gz', 'FILE_2.warc.gz', 'FILE_3.warc.gz'] }
+
+    before do
+      allow(described_class).to receive(:new).and_return(remediator)
+    end
+
+    it 'invokes audit' do
       expect(job_directory).to eq('AIT_12189/patch-missing-2021_01_01')
-      expect(FileUtils).to have_received(:mkdir_p).with('spec/fixtures/jobs/AIT_12189/patch-missing-2021_01_01')
-      expect(Open3).to have_received(:capture3).with('wasapi-downloader/bin/wasapi-downloader', '--filename',
-                                                     'AIT-12189-1.warc.gz', '--baseurl', 'https://archive-it.org/',
-                                                     '--authurl', 'https://archive-it.org/login', '--username', 'user',
-                                                     '--password', 'pass',
-                                                     '--outputBaseDir',
-                                                     'spec/fixtures/jobs/AIT_12189/patch-missing-2021_01_01/',
-                                                     '--resume')
-      expect(RegistrationJob).to have_received(:create!).with(admin_policy: 'druid:wr005wn5739',
-                                                              collection: 'druid:gq319xk9269',
-                                                              job_directory: 'AIT_12189/patch-missing-2021_01_01',
-                                                              source_id: 'sul:AIT-12189-patch-missing-2021_01_01')
-      expect(RegisterJob).to have_received(:perform_later).with(registration_job)
-    end
-  end
-
-  context 'when fetch fails' do
-    let(:status) { instance_double(Process::Status, success?: false) }
-
-    before do
-      allow(Open3).to receive(:capture3).and_return([nil, 'Not found', status])
-    end
-
-    it 'raises an error' do
-      expect { job_directory }.to raise_error(RuntimeError, 'Fetching WARCs failed: Not found')
+      expect(described_class).to have_received(:new).with(collection_druid: 'druid:hw105qf0103',
+                                                          wasapi_collection_id: '12189',
+                                                          wasapi_account: 'ua',
+                                                          wasapi_provider: 'ait',
+                                                          filenames: filenames,
+                                                          admin_policy_druid: 'druid:wr005wn5739',
+                                                          source_id: nil)
     end
   end
 end


### PR DESCRIPTION
closes #504

## Why was this change made? 🤔
Not all collections that require auditing/remediation are in WRA.


## How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning (and maybe even SWAP system?) works properly in [stage|qa] environment, in addition to specs. ⚡

QA
