### PR TITLE
Rake task for listing WARCs

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,12 @@ For example:
 RAILS_ENV=production bin/rake remediate_collection['druid:hw105qf0103']`
 RAILS_ENV=production bin/rake remediate['druid:gq319xk9269','14373','shl','1']
 ```
+
+## WARC Listing
+
+If you would like to get a CSV of all the WARC files and their metadata (size,
+md5, sha1, etc) from a collection's WASAPI provider you can:
+
+```
+RAILS_ENV=production bin/rake warcs[druid:yh729xg0576]
+```

--- a/app/services/audit/warc_auditer.rb
+++ b/app/services/audit/warc_auditer.rb
@@ -35,8 +35,12 @@ module Audit
     attr_reader :collection_druid, :wasapi_collection_id, :wasapi_account, :wasapi_provider, :embargo_months
 
     def wasapi_warc_filenames
-      WasapiWarcLister.new(wasapi_collection_id: wasapi_collection_id, wasapi_provider: wasapi_provider,
-                           wasapi_account: wasapi_account, embargo_months: embargo_months).to_a
+      WasapiWarcLister.new(
+        wasapi_collection_id: wasapi_collection_id,
+        wasapi_provider: wasapi_provider,
+        wasapi_account: wasapi_account,
+        embargo_months: embargo_months
+      ).pluck(:filename)
     end
 
     def sdr_warc_filenames

--- a/app/services/audit/wasapi_warc_lister.rb
+++ b/app/services/audit/wasapi_warc_lister.rb
@@ -1,7 +1,20 @@
 # frozen_string_literal: true
 
 module Audit
-  # Enumberable that returns WARC filenames for a collection from a WASAPI provider.
+  # A record for a WARC file available from a Wasapi service
+  WasapiRecord = Struct.new(
+    :filename,
+    :md5,
+    :sha1,
+    :bytes,
+    :crawl_time,
+    :crawl_start,
+    :store_time,
+    :url,
+    keyword_init: true
+  )
+
+  # Enumberable that returns WasapiRecords for a collection.
   class WasapiWarcLister
     include Enumerable
     def initialize(wasapi_collection_id:, wasapi_provider:, wasapi_account:, embargo_months: 0)
@@ -11,16 +24,15 @@ module Audit
       @embargo_months = embargo_months
     end
 
+    # Iterate through WARC file metadata, or return as a list
     def each(&block)
-      if block_given?
-        next_url = first_page_url
-        while next_url
-          response = get_page(next_url)
-          files_for(response).each { |file| block.call(file) }
-          next_url = response[:next]
-        end
-      else
-        to_enum(:each)
+      return to_enum(:each) unless block_given?
+
+      next_url = first_page_url
+      while next_url
+        response = get_page(next_url)
+        response[:files].each { |file| block.call(record_for_file(file)) }
+        next_url = response[:next]
       end
     end
 
@@ -58,12 +70,21 @@ module Audit
       JSON.parse(response.body).with_indifferent_access
     end
 
-    def files_for(response)
-      response[:files].pluck(:filename)
-    end
-
     def before_date
       (Time.zone.today - embargo_months.months).strftime('%Y-%m-01')
+    end
+
+    def record_for_file(file)
+      WasapiRecord.new(
+        filename: file['filename'],
+        md5: file['checksums']['md5'],
+        sha1: file['checksums']['sha1'],
+        bytes: file['size'],
+        crawl_time: file['crawl-time'],
+        crawl_start: file['crawl-start'],
+        store_time: file['store-time'],
+        url: file['locations'][0]
+      )
     end
   end
 end

--- a/lib/tasks/warcs.rake
+++ b/lib/tasks/warcs.rake
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'csv'
+
+desc 'List WARC files for a given collection id'
+task :warcs, %i[druid] => :environment do |_task, args|
+  collection = Collection.find_by!(druid: args[:druid])
+
+  warc_lister = Audit::WasapiWarcLister.new(
+    wasapi_provider: collection.wasapi_provider,
+    wasapi_account: collection.wasapi_account,
+    wasapi_collection_id: collection.wasapi_collection_id
+  )
+
+  CSV do |csv|
+    csv << %w[filename md5 sha1 bytes crawl_time crawl_start store_time url]
+    warc_lister.each do |file|
+      csv << [
+        file.filename,
+        file.md5,
+        file.sha1,
+        file.bytes,
+        file.crawl_time,
+        file.crawl_start,
+        file.store_time,
+        file.url
+      ]
+    end
+  end
+end

--- a/spec/services/audit/warc_auditer_spec.rb
+++ b/spec/services/audit/warc_auditer_spec.rb
@@ -10,8 +10,20 @@ RSpec.describe Audit::WarcAuditer do
     end
 
     before do
-      allow(Audit::WasapiWarcLister).to receive(:new).and_return(['FILE_1.warc.gz', 'FILE_2.warc.gz', 'FILE_3.warc.gz'])
-      allow(Audit::SdrWarcLister).to receive(:new).and_return(['FILE_2.warc.gz', 'FILE_3.warc.gz', 'FILE_4.warc.gz'])
+      allow(Audit::WasapiWarcLister).to receive(:new).and_return(
+        [
+          Audit::WasapiRecord.new(filename: 'FILE_1.warc.gz'),
+          Audit::WasapiRecord.new(filename: 'FILE_2.warc.gz'),
+          Audit::WasapiRecord.new(filename: 'FILE_3.warc.gz')
+        ]
+      )
+      allow(Audit::SdrWarcLister).to receive(:new).and_return(
+        [
+          'FILE_2.warc.gz',
+          'FILE_3.warc.gz',
+          'FILE_4.warc.gz'
+        ]
+      )
     end
 
     it 'returns missing files' do

--- a/spec/services/audit/wasapi_warc_lister_spec.rb
+++ b/spec/services/audit/wasapi_warc_lister_spec.rb
@@ -4,8 +4,12 @@ require 'rails_helper'
 
 RSpec.describe Audit::WasapiWarcLister do
   let(:files) do
-    described_class.new(wasapi_collection_id: '12189', wasapi_provider: 'ait', wasapi_account: 'ua',
-                        embargo_months: 3).to_a
+    described_class.new(
+      wasapi_collection_id: '12189',
+      wasapi_provider: 'ait',
+      wasapi_account: 'ua',
+      embargo_months: 3
+    )
   end
 
   before do
@@ -67,13 +71,17 @@ RSpec.describe Audit::WasapiWarcLister do
         .to_return(status: 200, body: body, headers: {})
     end
 
-    it 'returns files' do
-      expect(files).to eq(
-        [
-          'ARCHIVEIT-12189-ONE_TIME-JOB915353-SEED2014399-20190524001959215-00002-h3.warc.gz',
-          'ARCHIVEIT-12189-ONE_TIME-JOB915353-SEED2014399-20190523233238785-00001-h3.warc.gz'
-        ]
+    it 'iterates' do
+      results = files.to_a
+      expect(results[0].filename).to eq(
+        'ARCHIVEIT-12189-ONE_TIME-JOB915353-SEED2014399-20190524001959215-00002-h3.warc.gz'
       )
+      expect(results[0].md5).to eq('611182afc6b5986c93b99c826bdbf2cf')
+
+      expect(results[1].filename).to eq(
+        'ARCHIVEIT-12189-ONE_TIME-JOB915353-SEED2014399-20190523233238785-00001-h3.warc.gz'
+      )
+      expect(results[1].md5).to eq('6599bd32ebc09b6036cd63dfc886d517')
     end
   end
 
@@ -89,9 +97,9 @@ RSpec.describe Audit::WasapiWarcLister do
         .to_return(status: 403, body: '', headers: {})
     end
 
-    it 'raises' do
+    it 'raises 403' do
       expect do
-        files
+        files.to_a
       end.to raise_error('Getting https://archive-it.org/webdata?collection=12189&crawl-start-before=2020-10-01 ' \
                          'returned 403')
     end


### PR DESCRIPTION
## Why was this change made? 🤔

To help resolve a production issue we wanted to see what WARC files were available from Archive-It for a given collection. This adds a task to support fetching metadata for WARC files that are available from the WASAPI provider for a given collection druid:

```
RAILS_ENV=production bin/rake warcs[druid:yh729xg0576]
```

The CSV will contain filename, md5, sha1, size, crawl_time, crawl_start, store_time, and location.

## How was this change tested? 🤨

Running the rake task in development with a copy of the production database and configuration.
