### PR TITLE
catch up on missing rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -485,3 +485,14 @@ RSpec/SpecFilePathFormat: # new in 2.24
   Enabled: true
 RSpec/SpecFilePathSuffix: # new in 2.24
   Enabled: true
+
+Gemspec/AddRuntimeDependency: # new in 1.65
+  Enabled: true
+Style/MapIntoArray: # new in 1.63
+  Enabled: true
+Style/SendWithLiteralMethodName: # new in 1.64
+  Enabled: true
+Style/SuperArguments: # new in 1.64
+  Enabled: true
+Rails/WhereRange: # new in 2.25
+  Enabled: true


### PR DESCRIPTION
# Why was this change made? 🤔

noticed this when i was running tests locally while working on weekly dependency updates.

# How was this change tested? 🤨

ran rspec locally, CI

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning (and maybe even SWAP system?) works properly in [stage|qa] environment, in addition to specs. ⚡

n/a

# Does your change introduce accessibility violations? 🩺

no

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



