### PR TITLE
Linter touchups

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,6 @@
 inherit_from: .rubocop_todo.yml
 
-require:
+plugins:
   - rubocop-capybara
   - rubocop-factory_bot
   - rubocop-rails

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -496,3 +496,72 @@ Style/SuperArguments: # new in 1.64
   Enabled: true
 Rails/WhereRange: # new in 2.25
   Enabled: true
+
+Lint/ArrayLiteralInRegexp: # new in 1.71
+  Enabled: true
+Lint/ConstantReassignment: # new in 1.70
+  Enabled: true
+Lint/CopDirectiveSyntax: # new in 1.72
+  Enabled: true
+Lint/DuplicateSetElement: # new in 1.67
+  Enabled: true
+Lint/HashNewWithKeywordArgumentsAsDefault: # new in 1.69
+  Enabled: true
+Lint/NumericOperationWithConstantResult: # new in 1.69
+  Enabled: true
+Lint/RedundantTypeConversion: # new in 1.72
+  Enabled: true
+Lint/SharedMutableDefault: # new in 1.70
+  Enabled: true
+Lint/SuppressedExceptionInNumberConversion: # new in 1.72
+  Enabled: true
+Lint/UnescapedBracketInRegexp: # new in 1.68
+  Enabled: true
+Lint/UselessConstantScoping: # new in 1.72
+  Enabled: true
+Lint/UselessDefined: # new in 1.69
+  Enabled: true
+Lint/UselessNumericOperation: # new in 1.66
+  Enabled: true
+Style/AmbiguousEndlessMethodDefinition: # new in 1.68
+  Enabled: true
+Style/BitwisePredicate: # new in 1.68
+  Enabled: true
+Style/CombinableDefined: # new in 1.68
+  Enabled: true
+Style/ComparableBetween: # new in 1.74
+  Enabled: true
+Style/DigChain: # new in 1.69
+  Enabled: true
+Style/FileNull: # new in 1.69
+  Enabled: true
+Style/FileTouch: # new in 1.69
+  Enabled: true
+Style/HashFetchChain: # new in 1.75
+  Enabled: true
+Style/HashSlice: # new in 1.71
+  Enabled: true
+Style/ItAssignment: # new in 1.70
+  Enabled: true
+Style/ItBlockParameter: # new in 1.75
+  Enabled: true
+Style/KeywordArgumentsMerging: # new in 1.68
+  Enabled: true
+Style/RedundantFormat: # new in 1.72
+  Enabled: true
+Style/RedundantInterpolationUnfreeze: # new in 1.66
+  Enabled: true
+Style/SafeNavigationChainLength: # new in 1.68
+  Enabled: true
+Capybara/FindAllFirst: # new in 2.22
+  Enabled: true
+Capybara/NegationMatcherAfterVisit: # new in 2.22
+  Enabled: true
+Rails/EnumSyntax: # new in 2.26
+  Enabled: true
+Rails/MultipleRoutePaths: # new in 2.29
+  Enabled: true
+Rails/StrongParametersExpect: # new in 2.29
+  Enabled: true
+RSpec/IncludeExamples: # new in 3.6
+  Enabled: true

--- a/Rakefile
+++ b/Rakefile
@@ -24,6 +24,11 @@ begin
 
   desc 'Run all configured linters'
   task lint: %i[rubocop erblint eslint]
+
+  # clear the default task injected by rspec
+  task(:default).clear
+
+  task default: %i[lint spec]
 rescue LoadError
   # should only be here when gem group development and test aren't installed
 end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -53,19 +53,14 @@ class CollectionsController < ApplicationController
   private
 
   def collection_params
-    params.require(:collection).permit(:title,
-                                       :druid,
-                                       :embargo_months,
-                                       :fetch_start_month,
-                                       :active,
-                                       :wasapi_provider_account,
-                                       :wasapi_collection_id)
+    params.expect(collection: %i[title druid embargo_months fetch_start_month
+                                 active wasapi_provider_account wasapi_collection_id])
   end
 
   def wasapi_provider_accounts
     @wasapi_provider_accounts = []
     Settings.wasapi_providers.each do |provider, provider_info|
-      provider_info.accounts.each do |account, _| # rubocop:disable Style/HashEachMethods rubocop thinks each entry is a regular Hash, but accounts elements are actually Arrays of the form [Symbol, Config::options].  so there's no each_key method.
+      provider_info.accounts.each do |account, _| # rubocop:disable Style/HashEachMethods -- rubocop thinks each entry is a regular Hash, but accounts elements are actually Arrays of the form [Symbol, Config::options].  so there's no each_key method.
         @wasapi_provider_accounts << ["#{provider_info.name} (#{provider}) > #{account}",
                                       "#{provider}:#{account}"]
       end

--- a/app/controllers/registration_jobs_controller.rb
+++ b/app/controllers/registration_jobs_controller.rb
@@ -25,6 +25,6 @@ class RegistrationJobsController < ApplicationController
   private
 
   def registration_job_params
-    params.require(:registration_job).permit(:job_directory, :collection, :admin_policy, :source_id)
+    params.expect(registration_job: %i[job_directory collection admin_policy source_id])
   end
 end


### PR DESCRIPTION
# Why was this change made? 🤔

* it's nice to have the default rake task run the specs and the linters, and is consistent with most of our other projects
* it's helpful to not get too behind on rubocop rules

# How was this change tested? 🤨

⚡ ⚠ If this change involves consuming from other services or writing to shared file systems, test that web archive seed and crawl accessioning (and maybe even SWAP system?) works properly in [stage|qa] environment, in addition to specs. ⚡



# Does your change introduce accessibility violations? 🩺

⚡ ⚠ Please ensure this change does not introduce accessibility violations (at the WCAG A or AA conformance levels); if it does, include a rationale. See the [Infrastructure accessibility guide](https://github.com/sul-dlss/DeveloperPlaybook/blob/main/best-practices/infra-accessibility.md) for more detail. ⚡



