### PR TITLE
Update Sidekiq Worker usage

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,6 +232,7 @@ GEM
     faraday-retry (2.4.0)
       faraday (~> 2.0)
     ffi (1.17.4)
+    ffi (1.17.4-aarch64-linux-gnu)
     ffi (1.17.4-arm64-darwin)
     ffi (1.17.4-x86_64-darwin)
     ffi (1.17.4-x86_64-linux-gnu)
@@ -258,6 +259,8 @@ GEM
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.20.0)
+    jsonschema_rs (0.46.8-aarch64-linux)
+      bigdecimal (>= 3.1, < 5)
     jsonschema_rs (0.46.8-arm64-darwin)
       bigdecimal (>= 3.1, < 5)
     jsonschema_rs (0.46.8-x86_64-darwin)
@@ -304,6 +307,8 @@ GEM
       net-protocol
     net-ssh (7.3.3)
     nio4r (2.7.5)
+    nokogiri (1.19.4-aarch64-linux-gnu)
+      racc (~> 1.4)
     nokogiri (1.19.4-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-darwin)
@@ -321,6 +326,7 @@ GEM
     patience_diff (1.2.0)
       optimist (~> 3.0)
     pg (1.6.3)
+    pg (1.6.3-aarch64-linux)
     pg (1.6.3-arm64-darwin)
     pg (1.6.3-x86_64-darwin)
     pg (1.6.3-x86_64-linux)
@@ -531,6 +537,7 @@ GEM
     zeitwerk (2.8.2)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-25
   x86_64-darwin-20
   x86_64-linux

--- a/app/services/job_lister.rb
+++ b/app/services/job_lister.rb
@@ -30,7 +30,7 @@ class JobLister
 
   def payloads
     workers.map do |_, _, work|
-      work['payload']
+      work.payload
     end.compact
   end
 end

--- a/spec/services/job_lister_spec.rb
+++ b/spec/services/job_lister_spec.rb
@@ -19,8 +19,7 @@ RSpec.describe JobLister do
   end
 
   context 'when there are current jobs' do
-    let(:workers) { instance_double(Sidekiq::Workers) }
-    let(:work) do
+    let(:payload) do
       gid = "gid://was-registrar-app/FetchMonth/#{fetch_month.id}"
       {
         'args' => [
@@ -33,10 +32,10 @@ RSpec.describe JobLister do
         ]
       }.to_json
     end
+    let(:sidekiq_work) { Sidekiq::Work.new('pid', 'tid', { 'payload' => payload, 'queue' => 'default', 'run_at' => Time.now.to_i }) }
 
     before do
-      allow(Sidekiq::Workers).to receive(:new).and_return(workers)
-      allow(workers).to receive(:map).and_return([nil, work])
+      allow(Sidekiq::Workers).to receive(:new).and_return([['pid', 'tid', sidekiq_work]])
     end
 
     it 'returns FetchMonths for those jobs' do


### PR DESCRIPTION
# Why was this change made? 🤔
To resolve: [HB error](https://app.honeybadger.io/projects/63547/faults/126324153)

Per Claude:

> This is a version-drift bug, not a code error: [job_lister.rb:33](vscode-webview://028t8snej68euu2ieajgaq3u5fmlgqisfe7ht043chh1nlih7df9/app/services/job_lister.rb#L33) was written when Sidekiq::Workers#each yielded a Hash-like work object (older Sidekiq versions supported work['payload']). At some point Sidekiq's gem was upgraded (current lockfile: sidekiq (8.1.6)), and Sidekiq::Work became a real object exposing .payload instead of #[]. It only errors "sometimes" because it's only hit when there are actual running jobs for Sidekiq::Workers.new to enumerate — when the queue is empty, workers.map never yields, so the broken line is never executed.

> Fix: change line 33 to use the accessor method instead of hash indexing

# How was this change tested? 🤨
CI, ran integration test on stage.


